### PR TITLE
Add Nyaimlab management API backend and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,38 @@ python -m src.esclbot.bot
 ## Deploy
 - Local: run the module as above
 - Docker (optional): you can add a simple Dockerfile; PRs welcome
+
+## Nyaimlab Management API (Pages Dashboard Backend)
+
+The repository now also includes a FastAPI backend that fulfils the management
+API described in the Nyaimlab dashboard requirements.  It exposes
+`POST /api/*` endpoints for Pages clients and persists state in an in-memory
+store with audit logging.
+
+### Start the API locally
+
+```bash
+pip install -r requirements.txt
+python -m src.nyaimlab  # serves on 0.0.0.0:8080 by default
+```
+
+Set `API_AUTH_TOKEN` to the bearer token that the Pages frontend will use. All
+requests must provide:
+
+- `Authorization: Bearer <token>`
+- `x-client`: dashboard identifier
+- `x-guild-id`: Discord guild identifier
+- `x-user-id`: operator (used for audit logs)
+
+### Implemented routes (summary)
+
+- `/api/welcome.post` – configure the welcome embed (buttons, templates, etc.)
+- `/api/guideline.save` / `/api/guideline.test` – manage DM guideline content
+- `/api/verify.post` / `/api/verify.remove` – manage the `/verify` automation
+- `/api/roles.*` – configure role distribution, emoji mapping and preview
+- `/api/introduce.post` / `/api/introduce.schema.save` – customise `/introduce`
+- `/api/scrims.config.save` / `/api/scrims.run` – scrim helper configuration
+- `/api/audit.search` / `/api/audit.export` – fetch audit logs (CSV/NDJSON)
+- `/api/settings.save` – shared settings for locale/timezone/member index
+
+All responses follow `{"ok": bool, "error"?, "data"?, "audit_id"?}`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ pandas>=2.2.0
 httpx>=0.27.0
 beautifulsoup4>=4.12.3
 python-dotenv>=1.0.1
+fastapi>=0.110.0
+uvicorn[standard]>=0.29.0
+pytest>=8.2.0

--- a/src/nyaimlab/__init__.py
+++ b/src/nyaimlab/__init__.py
@@ -1,0 +1,6 @@
+"""Nyaimlab admin API package."""
+from __future__ import annotations
+
+from .app import app, create_app
+
+__all__ = ["app", "create_app"]

--- a/src/nyaimlab/__main__.py
+++ b/src/nyaimlab/__main__.py
@@ -1,0 +1,16 @@
+"""Entry point for running the Nyaimlab admin API."""
+from __future__ import annotations
+
+import os
+
+import uvicorn
+
+
+def main() -> None:
+    host = os.getenv("API_HOST", "0.0.0.0")
+    port = int(os.getenv("API_PORT", "8080"))
+    uvicorn.run("nyaimlab.app:app", host=host, port=port, reload=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nyaimlab/app.py
+++ b/src/nyaimlab/app.py
@@ -1,0 +1,217 @@
+"""FastAPI application exposing the Nyaimlab management API."""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request, status
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
+from .auth import require_context
+from .context import RequestContext
+from .schemas import (
+    APIResponse,
+    AuditExportRequest,
+    AuditSearchRequest,
+    GuidelineTemplate,
+    GuidelineTestRequest,
+    IntroduceConfig,
+    IntroduceSchema,
+    RoleEmojiMapRequest,
+    RoleRemovalRequest,
+    RolesConfig,
+    RolesPreviewRequest,
+    ScrimConfig,
+    ScrimRunRequest,
+    SettingsPayload,
+    VerifyConfig,
+    WelcomeConfig,
+)
+from .store import STORE
+
+
+def _success(audit_entry, data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {"ok": True, "audit_id": audit_entry.audit_id, "data": data}
+    return payload
+
+
+def _failure(status_code: int, message: str, audit_entry=None) -> JSONResponse:
+    body: Dict[str, Any] = {"ok": False, "error": message}
+    if audit_entry is not None:
+        body["audit_id"] = audit_entry.audit_id
+    return JSONResponse(status_code=status_code, content=body)
+
+
+router = APIRouter(prefix="/api")
+
+
+@router.post("/welcome.post", response_model=APIResponse)
+def welcome_post(
+    payload: WelcomeConfig, ctx: RequestContext = Depends(require_context)
+) -> Dict[str, Any]:
+    config, audit_entry = STORE.save_welcome(ctx, payload)
+    return _success(audit_entry, {"config": config})
+
+
+@router.post("/guideline.save", response_model=APIResponse)
+def guideline_save(
+    payload: GuidelineTemplate, ctx: RequestContext = Depends(require_context)
+) -> Dict[str, Any]:
+    template, audit_entry = STORE.save_guideline(ctx, payload)
+    return _success(audit_entry, {"template": template})
+
+
+@router.post("/guideline.test", response_model=APIResponse)
+def guideline_test(
+    payload: GuidelineTestRequest, ctx: RequestContext = Depends(require_context)
+) -> Dict[str, Any]:
+    preview, audit_entry = STORE.test_guideline(ctx, payload)
+    return _success(audit_entry, {"preview": preview})
+
+
+@router.post("/verify.post", response_model=APIResponse)
+def verify_post(
+    payload: VerifyConfig, ctx: RequestContext = Depends(require_context)
+) -> Dict[str, Any]:
+    config, audit_entry = STORE.save_verify(ctx, payload)
+    return _success(audit_entry, {"config": config})
+
+
+@router.post("/verify.remove", response_model=APIResponse)
+def verify_remove(ctx: RequestContext = Depends(require_context)) -> Dict[str, Any]:
+    audit_entry = STORE.remove_verify(ctx)
+    return _success(audit_entry)
+
+
+@router.post("/roles.post", response_model=APIResponse)
+def roles_post(
+    payload: RolesConfig, ctx: RequestContext = Depends(require_context)
+) -> Dict[str, Any]:
+    config, audit_entry = STORE.save_roles(ctx, payload)
+    return _success(audit_entry, {"config": config})
+
+
+@router.post("/roles.mapEmoji", response_model=APIResponse)
+def roles_map_emoji(
+    payload: RoleEmojiMapRequest, ctx: RequestContext = Depends(require_context)
+) -> Dict[str, Any]:
+    mapping, audit_entry = STORE.map_role_emoji(ctx, payload)
+    return _success(audit_entry, {"mapping": mapping})
+
+
+@router.post("/roles.remove", response_model=APIResponse)
+def roles_remove(
+    payload: RoleRemovalRequest, ctx: RequestContext = Depends(require_context)
+) -> Dict[str, Any]:
+    config, audit_entry = STORE.remove_role(ctx, payload)
+    return _success(audit_entry, {"config": config})
+
+
+@router.post("/roles.preview", response_model=APIResponse)
+def roles_preview(
+    payload: RolesPreviewRequest, ctx: RequestContext = Depends(require_context)
+) -> Dict[str, Any]:
+    preview, audit_entry = STORE.preview_roles(ctx, payload)
+    return _success(audit_entry, {"preview": preview})
+
+
+@router.post("/introduce.post", response_model=APIResponse)
+def introduce_post(
+    payload: IntroduceConfig, ctx: RequestContext = Depends(require_context)
+) -> Dict[str, Any]:
+    config, audit_entry = STORE.save_introduce(ctx, payload)
+    return _success(audit_entry, {"config": config})
+
+
+@router.post("/introduce.schema.save", response_model=APIResponse)
+def introduce_schema_save(
+    payload: IntroduceSchema, ctx: RequestContext = Depends(require_context)
+) -> JSONResponse | Dict[str, Any]:
+    try:
+        schema, audit_entry = STORE.save_introduce_schema(ctx, payload)
+    except ValueError as exc:  # duplicate field IDs, etc.
+        audit_entry = STORE.log_failure(
+            ctx,
+            "introduce.schema.save",
+            str(exc),
+            payload=payload.model_dump(mode="python"),
+        )
+        return _failure(status.HTTP_400_BAD_REQUEST, str(exc), audit_entry)
+    return _success(audit_entry, {"schema": schema})
+
+
+@router.post("/scrims.config.save", response_model=APIResponse)
+def scrims_config_save(
+    payload: ScrimConfig, ctx: RequestContext = Depends(require_context)
+) -> Dict[str, Any]:
+    config, audit_entry = STORE.save_scrim_config(ctx, payload)
+    return _success(audit_entry, {"config": config})
+
+
+@router.post("/scrims.run", response_model=APIResponse)
+def scrims_run(
+    payload: ScrimRunRequest, ctx: RequestContext = Depends(require_context)
+) -> JSONResponse | Dict[str, Any]:
+    try:
+        result, audit_entry = STORE.run_scrim(ctx, payload)
+    except ValueError as exc:
+        audit_entry = STORE.log_failure(
+            ctx,
+            "scrims.run",
+            str(exc),
+            payload={"dry_run": payload.dry_run},
+        )
+        return _failure(status.HTTP_400_BAD_REQUEST, str(exc), audit_entry)
+    return _success(audit_entry, {"result": result})
+
+
+@router.post("/settings.save", response_model=APIResponse)
+def settings_save(
+    payload: SettingsPayload, ctx: RequestContext = Depends(require_context)
+) -> Dict[str, Any]:
+    settings, audit_entry = STORE.save_settings(ctx, payload)
+    return _success(audit_entry, {"settings": settings})
+
+
+@router.post("/audit.search", response_model=APIResponse)
+def audit_search(
+    payload: AuditSearchRequest, ctx: RequestContext = Depends(require_context)
+) -> Dict[str, Any]:
+    results, audit_entry = STORE.search_audit(ctx, payload)
+    return _success(audit_entry, {"results": results})
+
+
+@router.post("/audit.export", response_model=APIResponse)
+def audit_export(
+    payload: AuditExportRequest, ctx: RequestContext = Depends(require_context)
+) -> Dict[str, Any]:
+    content, audit_entry = STORE.export_audit(ctx, payload)
+    data = {"format": payload.format.value, "content": content}
+    return _success(audit_entry, data)
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="Nyaimlab Management API", version="0.1.0")
+
+    @app.exception_handler(RequestValidationError)
+    async def validation_exception_handler(  # type: ignore[override]
+        request: Request, exc: RequestValidationError
+    ) -> JSONResponse:
+        message = "Validation error"
+        return _failure(status.HTTP_422_UNPROCESSABLE_ENTITY, f"{message}: {exc}")
+
+    @app.exception_handler(HTTPException)
+    async def http_exception_handler(  # type: ignore[override]
+        request: Request, exc: HTTPException
+    ) -> JSONResponse:
+        return _failure(exc.status_code, str(exc.detail))
+
+    @app.get("/healthz")
+    async def healthcheck() -> Dict[str, Any]:
+        return {"ok": True}
+
+    app.include_router(router)
+    return app
+
+
+app = create_app()

--- a/src/nyaimlab/auth.py
+++ b/src/nyaimlab/auth.py
@@ -1,0 +1,59 @@
+"""Authentication helpers for the management API."""
+from __future__ import annotations
+
+import os
+from typing import Tuple
+
+from fastapi import Header, HTTPException, status
+
+from .context import RequestContext
+
+
+def _extract_bearer_token(authorization: str) -> str:
+    if not authorization:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing Authorization header")
+    prefix = "Bearer "
+    if not authorization.startswith(prefix):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid Authorization scheme")
+    token = authorization[len(prefix) :].strip()
+    if not token:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Empty bearer token")
+    return token
+
+
+def _normalize_scopes(raw_scopes: str | None) -> Tuple[str, ...]:
+    if not raw_scopes:
+        return ()
+    items = []
+    for piece in raw_scopes.split(","):
+        item = piece.strip()
+        if item:
+            items.append(item)
+    return tuple(items)
+
+
+def require_context(
+    authorization: str = Header(..., alias="Authorization"),
+    x_client: str = Header(..., alias="x-client"),
+    x_guild_id: str = Header(..., alias="x-guild-id"),
+    x_user_id: str | None = Header(None, alias="x-user-id"),
+    x_scopes: str | None = Header(None, alias="x-scopes"),
+) -> RequestContext:
+    """Validate headers and produce a :class:`RequestContext`."""
+
+    token = _extract_bearer_token(authorization)
+    expected = os.getenv("API_AUTH_TOKEN")
+    if expected and token != expected:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid session token")
+
+    actor = x_user_id or "unknown"
+    if not x_guild_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing x-guild-id header")
+
+    return RequestContext(
+        guild_id=x_guild_id,
+        client_id=x_client,
+        session_id=token,
+        actor_id=actor,
+        scopes=_normalize_scopes(x_scopes),
+    )

--- a/src/nyaimlab/context.py
+++ b/src/nyaimlab/context.py
@@ -1,0 +1,26 @@
+"""Request context utilities for the admin API."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+
+@dataclass(frozen=True)
+class RequestContext:
+    """Metadata extracted from authenticated requests."""
+
+    guild_id: str
+    client_id: str
+    session_id: str
+    actor_id: str
+    scopes: Tuple[str, ...] = ()
+
+    def to_metadata(self) -> dict[str, str]:
+        """Return a serialisable metadata representation for audit logging."""
+
+        return {
+            "guild_id": self.guild_id,
+            "client_id": self.client_id,
+            "session_id": self.session_id,
+            "actor_id": self.actor_id,
+        }

--- a/src/nyaimlab/schemas.py
+++ b/src/nyaimlab/schemas.py
@@ -1,0 +1,344 @@
+"""Pydantic models for the Nyaimlab admin API."""
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import List, Optional
+
+from pydantic import (
+    AnyHttpUrl,
+    BaseModel,
+    ConfigDict,
+    Field,
+    FieldValidationInfo,
+    PositiveInt,
+    field_validator,
+)
+
+
+class MemberIndexMode(str, Enum):
+    """How to count members when calculating the welcome index."""
+
+    INCLUDE_BOTS = "include_bots"
+    EXCLUDE_BOTS = "exclude_bots"
+
+
+class Locale(str, Enum):
+    """Available locales for the dashboard and Discord output."""
+
+    JA_JP = "ja-JP"
+    EN_US = "en-US"
+
+
+class Timezone(str, Enum):
+    """Timezone options supported by the runtime."""
+
+    UTC = "UTC"
+    JST = "Asia/Tokyo"
+
+
+class WelcomeButtonTarget(str, Enum):
+    """Types of supported welcome buttons."""
+
+    URL = "url"
+    CHANNEL = "channel"
+
+
+class WelcomeButton(BaseModel):
+    """Button definition for the welcome embed."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    label: str = Field(..., min_length=1, max_length=80)
+    target: WelcomeButtonTarget
+    value: str = Field(..., min_length=1, max_length=256)
+    emoji: Optional[str] = Field(
+        default=None,
+        description="Optional custom emoji identifier (unicode or emoji ID).",
+    )
+
+
+class WelcomeConfig(BaseModel):
+    """Configuration payload for the welcome embed flow."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    channel_id: str = Field(..., min_length=1)
+    title_template: str = Field(
+        default="ようこそ、{username} さん！",
+        description="Title template supporting Discord format placeholders.",
+    )
+    description_template: str = Field(
+        default="あなたは **#{member_index}** 人目のメンバーです。",
+        description="Description template shown within the embed.",
+    )
+    member_index_mode: MemberIndexMode = MemberIndexMode.EXCLUDE_BOTS
+    join_field_label: str = Field(default="加入日時", max_length=32)
+    join_timezone: Timezone = Timezone.JST
+    buttons: List[WelcomeButton] = Field(default_factory=list)
+    footer_text: str = Field(default="Nyaimlab", max_length=64)
+    thread_name_template: Optional[str] = Field(
+        default=None,
+        description="Optional thread name template if follow-up threads are created.",
+    )
+
+
+class GuidelineTemplate(BaseModel):
+    """Stored DM guideline template."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    content: str = Field(
+        ..., min_length=1, description="Markdown or plain text sent via DM."
+    )
+    attachments: List[AnyHttpUrl] = Field(
+        default_factory=list,
+        description="Optional list of hosted asset URLs attached to the DM.",
+    )
+
+
+class GuidelineTestRequest(BaseModel):
+    """Request payload for testing the guideline DM."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    target_user_id: Optional[str] = Field(
+        default=None,
+        description="Optional Discord user ID to send a preview DM (simulated).",
+    )
+    dry_run: bool = Field(
+        default=True, description="If true, no persistent state is modified."
+    )
+
+
+class VerifyMode(str, Enum):
+    BUTTON = "button"
+    REACTION = "reaction"
+
+
+class VerifyConfig(BaseModel):
+    """Verification message configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    channel_id: str = Field(..., min_length=1)
+    role_id: str = Field(..., min_length=1)
+    mode: VerifyMode = VerifyMode.BUTTON
+    prompt: str = Field(
+        default="ボタンを押して認証を完了してください。",
+        max_length=2000,
+    )
+    message_id: Optional[str] = Field(
+        default=None,
+        description="Existing Discord message ID to update in-place if present.",
+    )
+
+
+class RoleStyle(str, Enum):
+    BUTTONS = "buttons"
+    SELECT = "select"
+    REACTIONS = "reactions"
+
+
+class RoleEntry(BaseModel):
+    """Definition for a self-assignable role."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    role_id: str = Field(..., min_length=1)
+    label: str = Field(..., min_length=1, max_length=80)
+    description: Optional[str] = Field(
+        default=None,
+        max_length=200,
+        description="Optional helper text shown on the dashboard.",
+    )
+    emoji: Optional[str] = Field(default=None, max_length=64)
+    hidden: bool = False
+    sort_order: int = Field(default=0)
+
+
+class RolesConfig(BaseModel):
+    """Configuration payload for the role distribution message."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    channel_id: str
+    style: RoleStyle
+    roles: List[RoleEntry] = Field(default_factory=list)
+    message_content: Optional[str] = Field(
+        default=None,
+        description="Optional plain-text message that accompanies the controls.",
+    )
+
+
+class RoleEmojiMapRequest(BaseModel):
+    """Payload for mapping or removing reaction emojis."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    role_id: str
+    emoji: Optional[str] = Field(
+        default=None,
+        description="Emoji to associate. None removes the mapping.",
+    )
+
+
+class RoleRemovalRequest(BaseModel):
+    """Request to remove a role configuration entry."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    role_id: Optional[str] = Field(
+        default=None,
+        description="If omitted the entire role panel is removed.",
+    )
+
+
+class RolesPreviewRequest(BaseModel):
+    """Request payload for generating a preview of the role UI."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    locale: Locale = Locale.JA_JP
+
+
+class IntroduceField(BaseModel):
+    """Definition of a modal field for the /introduce command."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    field_id: str = Field(..., min_length=1, max_length=32)
+    label: str = Field(..., min_length=1, max_length=45)
+    placeholder: Optional[str] = Field(default=None, max_length=100)
+    required: bool = Field(default=True)
+    enabled: bool = Field(default=True)
+    max_length: PositiveInt = Field(default=300, le=1024)
+
+
+class IntroduceSchema(BaseModel):
+    """Collection of fields that make up the introduction modal."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    fields: List[IntroduceField] = Field(default_factory=list)
+
+
+class IntroduceConfig(BaseModel):
+    """Configuration for posting introductions."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    channel_id: str
+    mention_role_ids: List[str] = Field(default_factory=list)
+    embed_title: str = Field(
+        default="自己紹介",
+        max_length=256,
+    )
+    footer_text: Optional[str] = Field(default=None, max_length=64)
+
+
+class ScrimDay(str, Enum):
+    SUN = "sun"
+    MON = "mon"
+    TUE = "tue"
+    WED = "wed"
+    THU = "thu"
+    FRI = "fri"
+    SAT = "sat"
+
+
+class ScrimRule(BaseModel):
+    """Configuration for weekly scrim surveys."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    day: ScrimDay = ScrimDay.SUN
+    survey_open_hour: int = Field(default=12, ge=0, le=23)
+    survey_close_hour: int = Field(default=22, ge=0, le=23)
+    notify_channel_id: str
+    min_team_members: PositiveInt = Field(default=3, le=10)
+
+    @field_validator("survey_close_hour")
+    @classmethod
+    def validate_close(cls, v: int, info: FieldValidationInfo):  # pragma: no cover - simple guard
+        data = info.data
+        if "survey_open_hour" in data and v == data["survey_open_hour"]:
+            raise ValueError("survey_close_hour must differ from survey_open_hour")
+        return v
+
+
+class ScrimConfig(BaseModel):
+    """Top-level scrim automation configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    timezone: Timezone = Timezone.JST
+    rules: List[ScrimRule] = Field(default_factory=list)
+    manager_role_id: Optional[str] = None
+
+
+class ScrimRunRequest(BaseModel):
+    """Manual trigger for the scrim helper."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    dry_run: bool = Field(default=True)
+
+
+class AuditSearchRequest(BaseModel):
+    """Search parameters for audit events."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    since: Optional[datetime] = None
+    until: Optional[datetime] = None
+    action: Optional[str] = Field(default=None, max_length=64)
+    user_id: Optional[str] = Field(default=None)
+    channel_id: Optional[str] = Field(default=None)
+    limit: PositiveInt = Field(default=100, le=500)
+
+
+class AuditExportFormat(str, Enum):
+    NDJSON = "ndjson"
+    CSV = "csv"
+
+
+class AuditExportRequest(AuditSearchRequest):
+    """Export request, extending the search parameters with a format."""
+
+    format: AuditExportFormat = AuditExportFormat.NDJSON
+
+
+class MemberCountStrategy(str, Enum):
+    ALL_MEMBERS = "all_members"
+    HUMAN_ONLY = "human_only"
+    BOOSTERS_PRIORITY = "boosters_priority"
+
+
+class SettingsPayload(BaseModel):
+    """Guild-level bot configuration that affects multiple features."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    locale: Locale = Locale.JA_JP
+    timezone: Timezone = Timezone.JST
+    member_index_mode: MemberIndexMode = MemberIndexMode.EXCLUDE_BOTS
+    member_count_strategy: MemberCountStrategy = MemberCountStrategy.HUMAN_ONLY
+    api_base_url: Optional[AnyHttpUrl] = Field(default=None)
+    show_join_alerts: bool = Field(default=True)
+
+
+class APIResponse(BaseModel):
+    """Consistent envelope for successful responses."""
+
+    ok: bool = True
+    audit_id: Optional[str] = None
+    data: Optional[dict] = None
+
+
+class ErrorResponse(BaseModel):
+    """Consistent envelope for errors."""
+
+    ok: bool = False
+    error: str
+    audit_id: Optional[str] = None

--- a/src/nyaimlab/store.py
+++ b/src/nyaimlab/store.py
@@ -1,0 +1,481 @@
+"""In-memory data store for the Nyaimlab management API."""
+from __future__ import annotations
+
+import csv
+import io
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from threading import Lock
+from typing import Any, Dict, List, Optional
+from uuid import uuid4
+
+from pydantic import BaseModel
+
+from .context import RequestContext
+from .schemas import (
+    AuditExportFormat,
+    AuditExportRequest,
+    AuditSearchRequest,
+    GuidelineTemplate,
+    GuidelineTestRequest,
+    IntroduceConfig,
+    IntroduceSchema,
+    RoleEmojiMapRequest,
+    RoleRemovalRequest,
+    RolesConfig,
+    RolesPreviewRequest,
+    ScrimConfig,
+    ScrimRunRequest,
+    SettingsPayload,
+    VerifyConfig,
+    WelcomeConfig,
+)
+
+
+def _dump_model(model: Optional[BaseModel]) -> Optional[Dict[str, Any]]:
+    """Convert a pydantic model into a plain dictionary."""
+
+    if model is None:
+        return None
+    return model.model_dump(mode="python")
+
+
+@dataclass
+class AuditEntry:
+    """Single audit log entry."""
+
+    audit_id: str
+    timestamp: datetime
+    guild_id: str
+    action: str
+    ok: bool
+    actor_id: str
+    client_id: str
+    session_id: str
+    payload: Optional[Dict[str, Any]] = None
+    error: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self, include_payload: bool = False) -> Dict[str, Any]:
+        data: Dict[str, Any] = {
+            "audit_id": self.audit_id,
+            "timestamp": self.timestamp.isoformat(),
+            "guild_id": self.guild_id,
+            "action": self.action,
+            "ok": self.ok,
+            "actor_id": self.actor_id,
+            "client_id": self.client_id,
+            "session_id": self.session_id,
+        }
+        if self.error:
+            data["error"] = self.error
+        if self.metadata:
+            data.update(self.metadata)
+        if include_payload and self.payload is not None:
+            data["payload"] = self.payload
+        return data
+
+
+@dataclass
+class GuildState:
+    """Stored state for a guild."""
+
+    welcome: Optional[Dict[str, Any]] = None
+    guideline: Optional[Dict[str, Any]] = None
+    verify: Optional[Dict[str, Any]] = None
+    roles: Optional[Dict[str, Any]] = None
+    role_emoji_map: Dict[str, str] = field(default_factory=dict)
+    introduce: Optional[Dict[str, Any]] = None
+    introduce_schema: Dict[str, Any] = field(default_factory=lambda: {"fields": []})
+    scrims: Optional[Dict[str, Any]] = None
+    settings: Dict[str, Any] = field(default_factory=dict)
+
+
+class Store:
+    """Thread-safe state container with audit logging."""
+
+    def __init__(self) -> None:
+        self._guilds: Dict[str, GuildState] = {}
+        self._audit: List[AuditEntry] = []
+        self._lock = Lock()
+
+    # ------------------------------------------------------------------
+    # Helper utilities
+    # ------------------------------------------------------------------
+    def _ensure_state(self, guild_id: str) -> GuildState:
+        state = self._guilds.get(guild_id)
+        if state is None:
+            state = GuildState()
+            self._guilds[guild_id] = state
+        return state
+
+    def _record_audit(
+        self,
+        ctx: RequestContext,
+        action: str,
+        *,
+        ok: bool,
+        payload: Optional[Dict[str, Any]] = None,
+        error: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> AuditEntry:
+        entry = AuditEntry(
+            audit_id=str(uuid4()),
+            timestamp=datetime.now(timezone.utc),
+            guild_id=ctx.guild_id,
+            action=action,
+            ok=ok,
+            actor_id=ctx.actor_id,
+            client_id=ctx.client_id,
+            session_id=ctx.session_id,
+            payload=payload,
+            error=error,
+            metadata=metadata or {},
+        )
+        with self._lock:
+            self._audit.append(entry)
+        return entry
+
+    # ------------------------------------------------------------------
+    # Welcome
+    # ------------------------------------------------------------------
+    def save_welcome(
+        self, ctx: RequestContext, payload: WelcomeConfig
+    ) -> tuple[Dict[str, Any], AuditEntry]:
+        data = _dump_model(payload) or {}
+        with self._lock:
+            state = self._ensure_state(ctx.guild_id)
+            state.welcome = data
+        entry = self._record_audit(
+            ctx,
+            "welcome.post",
+            ok=True,
+            payload=data,
+            metadata={"channel_id": payload.channel_id},
+        )
+        return data, entry
+
+    # ------------------------------------------------------------------
+    # Guideline
+    # ------------------------------------------------------------------
+    def save_guideline(
+        self, ctx: RequestContext, payload: GuidelineTemplate
+    ) -> tuple[Dict[str, Any], AuditEntry]:
+        data = _dump_model(payload) or {}
+        with self._lock:
+            state = self._ensure_state(ctx.guild_id)
+            state.guideline = data
+        entry = self._record_audit(
+            ctx,
+            "guideline.save",
+            ok=True,
+            payload=data,
+        )
+        return data, entry
+
+    def test_guideline(
+        self, ctx: RequestContext, request: GuidelineTestRequest
+    ) -> tuple[Dict[str, Any], AuditEntry]:
+        with self._lock:
+            state = self._ensure_state(ctx.guild_id)
+            preview = state.guideline.copy() if state.guideline else {}
+        preview.update({
+            "target_user_id": request.target_user_id,
+            "dry_run": request.dry_run,
+        })
+        entry = self._record_audit(
+            ctx,
+            "guideline.test",
+            ok=True,
+            payload=preview,
+        )
+        return preview, entry
+
+    # ------------------------------------------------------------------
+    # Verify
+    # ------------------------------------------------------------------
+    def save_verify(
+        self, ctx: RequestContext, payload: VerifyConfig
+    ) -> tuple[Dict[str, Any], AuditEntry]:
+        data = _dump_model(payload) or {}
+        with self._lock:
+            state = self._ensure_state(ctx.guild_id)
+            state.verify = data
+        entry = self._record_audit(
+            ctx,
+            "verify.post",
+            ok=True,
+            payload=data,
+            metadata={"channel_id": payload.channel_id},
+        )
+        return data, entry
+
+    def remove_verify(self, ctx: RequestContext) -> AuditEntry:
+        with self._lock:
+            state = self._ensure_state(ctx.guild_id)
+            state.verify = None
+        return self._record_audit(ctx, "verify.remove", ok=True)
+
+    # ------------------------------------------------------------------
+    # Roles
+    # ------------------------------------------------------------------
+    def save_roles(
+        self, ctx: RequestContext, payload: RolesConfig
+    ) -> tuple[Dict[str, Any], AuditEntry]:
+        data = _dump_model(payload) or {}
+        with self._lock:
+            state = self._ensure_state(ctx.guild_id)
+            state.roles = data
+        entry = self._record_audit(
+            ctx,
+            "roles.post",
+            ok=True,
+            payload=data,
+            metadata={"channel_id": payload.channel_id},
+        )
+        return data, entry
+
+    def map_role_emoji(
+        self, ctx: RequestContext, payload: RoleEmojiMapRequest
+    ) -> tuple[Dict[str, str], AuditEntry]:
+        with self._lock:
+            state = self._ensure_state(ctx.guild_id)
+            if payload.emoji:
+                state.role_emoji_map[payload.role_id] = payload.emoji
+            else:
+                state.role_emoji_map.pop(payload.role_id, None)
+            mapping = dict(state.role_emoji_map)
+        entry = self._record_audit(
+            ctx,
+            "roles.mapEmoji",
+            ok=True,
+            payload={"role_id": payload.role_id, "emoji": payload.emoji},
+        )
+        return mapping, entry
+
+    def remove_role(
+        self, ctx: RequestContext, payload: RoleRemovalRequest
+    ) -> tuple[Optional[Dict[str, Any]], AuditEntry]:
+        with self._lock:
+            state = self._ensure_state(ctx.guild_id)
+            if payload.role_id is None:
+                state.roles = None
+                state.role_emoji_map.clear()
+            elif state.roles:
+                roles = [r for r in state.roles.get("roles", []) if r["role_id"] != payload.role_id]
+                state.roles["roles"] = roles
+            current = state.roles.copy() if state.roles else None
+        entry = self._record_audit(
+            ctx,
+            "roles.remove",
+            ok=True,
+            payload={"role_id": payload.role_id},
+        )
+        return current, entry
+
+    def preview_roles(
+        self, ctx: RequestContext, payload: RolesPreviewRequest
+    ) -> tuple[Dict[str, Any], AuditEntry]:
+        with self._lock:
+            state = self._ensure_state(ctx.guild_id)
+            preview = {
+                "style": state.roles.get("style") if state.roles else None,
+                "roles": state.roles.get("roles", []) if state.roles else [],
+                "emoji_map": dict(state.role_emoji_map),
+                "locale": payload.locale.value,
+            }
+        entry = self._record_audit(
+            ctx,
+            "roles.preview",
+            ok=True,
+            payload={"locale": payload.locale.value},
+        )
+        return preview, entry
+
+    # ------------------------------------------------------------------
+    # Introduce
+    # ------------------------------------------------------------------
+    def save_introduce(
+        self, ctx: RequestContext, payload: IntroduceConfig
+    ) -> tuple[Dict[str, Any], AuditEntry]:
+        data = _dump_model(payload) or {}
+        with self._lock:
+            state = self._ensure_state(ctx.guild_id)
+            state.introduce = data
+        entry = self._record_audit(
+            ctx,
+            "introduce.post",
+            ok=True,
+            payload=data,
+            metadata={"channel_id": payload.channel_id},
+        )
+        return data, entry
+
+    def save_introduce_schema(
+        self, ctx: RequestContext, payload: IntroduceSchema
+    ) -> tuple[Dict[str, Any], AuditEntry]:
+        data = _dump_model(payload) or {}
+        ids = [field["field_id"] for field in data.get("fields", [])]
+        if len(ids) != len(set(ids)):
+            raise ValueError("Duplicate field_id detected in introduce schema")
+        with self._lock:
+            state = self._ensure_state(ctx.guild_id)
+            state.introduce_schema = data
+        entry = self._record_audit(
+            ctx,
+            "introduce.schema.save",
+            ok=True,
+            payload=data,
+        )
+        return data, entry
+
+    # ------------------------------------------------------------------
+    # Scrims
+    # ------------------------------------------------------------------
+    def save_scrim_config(
+        self, ctx: RequestContext, payload: ScrimConfig
+    ) -> tuple[Dict[str, Any], AuditEntry]:
+        data = _dump_model(payload) or {}
+        with self._lock:
+            state = self._ensure_state(ctx.guild_id)
+            state.scrims = data
+        entry = self._record_audit(
+            ctx,
+            "scrims.config.save",
+            ok=True,
+            payload=data,
+        )
+        return data, entry
+
+    def run_scrim(
+        self, ctx: RequestContext, payload: ScrimRunRequest
+    ) -> tuple[Dict[str, Any], AuditEntry]:
+        with self._lock:
+            state = self._ensure_state(ctx.guild_id)
+            if not state.scrims:
+                raise ValueError("Scrim configuration is not set")
+            actions = []
+            for rule in state.scrims.get("rules", []):
+                actions.append(
+                    {
+                        "day": rule.get("day"),
+                        "notify_channel_id": rule.get("notify_channel_id"),
+                        "min_team_members": rule.get("min_team_members"),
+                        "status": "dry_run" if payload.dry_run else "scheduled",
+                    }
+                )
+        result = {"actions": actions, "dry_run": payload.dry_run}
+        entry = self._record_audit(
+            ctx,
+            "scrims.run",
+            ok=True,
+            payload=result,
+        )
+        return result, entry
+
+    # ------------------------------------------------------------------
+    # Settings
+    # ------------------------------------------------------------------
+    def save_settings(
+        self, ctx: RequestContext, payload: SettingsPayload
+    ) -> tuple[Dict[str, Any], AuditEntry]:
+        data = _dump_model(payload) or {}
+        with self._lock:
+            state = self._ensure_state(ctx.guild_id)
+            state.settings.update(data)
+        entry = self._record_audit(
+            ctx,
+            "settings.save",
+            ok=True,
+            payload=data,
+        )
+        return data, entry
+
+    # ------------------------------------------------------------------
+    # Audit search/export
+    # ------------------------------------------------------------------
+    def search_audit(
+        self, ctx: RequestContext, payload: AuditSearchRequest
+    ) -> tuple[List[Dict[str, Any]], AuditEntry]:
+        results: List[AuditEntry]
+        with self._lock:
+            results = [entry for entry in self._audit if entry.guild_id == ctx.guild_id]
+        filtered: List[AuditEntry] = []
+        for entry in results:
+            if payload.action and entry.action != payload.action:
+                continue
+            if payload.user_id and entry.actor_id != payload.user_id:
+                continue
+            if payload.channel_id and entry.metadata.get("channel_id") != payload.channel_id:
+                continue
+            if payload.since and entry.timestamp < payload.since:
+                continue
+            if payload.until and entry.timestamp > payload.until:
+                continue
+            filtered.append(entry)
+        # Latest entries first for the dashboard
+        filtered.sort(key=lambda e: e.timestamp, reverse=True)
+        limited = filtered[: payload.limit]
+        data = [entry.to_dict(include_payload=True) for entry in limited]
+        audit_entry = self._record_audit(
+            ctx,
+            "audit.search",
+            ok=True,
+            payload={"results": len(data)},
+        )
+        return data, audit_entry
+
+    def export_audit(
+        self, ctx: RequestContext, payload: AuditExportRequest
+    ) -> tuple[str, AuditEntry]:
+        results, _ = self.search_audit(ctx, payload)
+        text: str
+        if payload.format == AuditExportFormat.NDJSON:
+            lines = [json.dumps(row, ensure_ascii=False) for row in results]
+            text = "\n".join(lines)
+        else:
+            buffer = io.StringIO()
+            rows = []
+            fieldnames = set()
+            for row in results:
+                row_copy = dict(row)
+                payload_data = row_copy.pop("payload", None)
+                if payload_data is not None:
+                    row_copy["payload"] = json.dumps(payload_data, ensure_ascii=False)
+                rows.append(row_copy)
+                fieldnames.update(row_copy.keys())
+            writer = csv.DictWriter(buffer, fieldnames=sorted(fieldnames))
+            writer.writeheader()
+            for row in rows:
+                writer.writerow(row)
+            text = buffer.getvalue()
+        audit_entry = self._record_audit(
+            ctx,
+            "audit.export",
+            ok=True,
+            payload={"format": payload.format.value, "bytes": len(text.encode("utf-8"))},
+        )
+        return text, audit_entry
+
+    def log_failure(
+        self,
+        ctx: RequestContext,
+        action: str,
+        message: str,
+        *,
+        payload: Optional[Dict[str, Any]] = None,
+    ) -> AuditEntry:
+        """Utility for endpoints to record failed operations."""
+
+        return self._record_audit(
+            ctx,
+            action,
+            ok=False,
+            error=message,
+            payload=payload,
+        )
+
+
+# Shared singleton store used by the API
+STORE = Store()

--- a/tests/test_nyaimlab_api.py
+++ b/tests/test_nyaimlab_api.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+"""Smoke tests for the Nyaimlab management API."""
+
+from typing import Dict
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.nyaimlab import create_app
+
+
+@pytest.fixture(autouse=True)
+def _set_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("API_AUTH_TOKEN", "secret-token")
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = create_app()
+    return TestClient(app)
+
+
+@pytest.fixture
+def auth_headers() -> Dict[str, str]:
+    return {
+        "Authorization": "Bearer secret-token",
+        "x-client": "pytest",
+        "x-guild-id": "guild-123",
+        "x-user-id": "user-456",
+    }
+
+
+def test_welcome_configuration(client: TestClient, auth_headers: Dict[str, str]) -> None:
+    resp = client.post(
+        "/api/welcome.post",
+        json={"channel_id": "123"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert "audit_id" in body
+    assert body["data"]["config"]["channel_id"] == "123"
+
+
+def test_guideline_template_roundtrip(client: TestClient, auth_headers: Dict[str, str]) -> None:
+    save_resp = client.post(
+        "/api/guideline.save",
+        json={"content": "Welcome", "attachments": []},
+        headers=auth_headers,
+    )
+    assert save_resp.json()["ok"] is True
+
+    test_resp = client.post(
+        "/api/guideline.test",
+        json={},
+        headers=auth_headers,
+    )
+    body = test_resp.json()
+    assert body["ok"] is True
+    assert body["data"]["preview"]["content"] == "Welcome"
+
+
+def test_introduce_schema_duplicate_error(client: TestClient, auth_headers: Dict[str, str]) -> None:
+    resp = client.post(
+        "/api/introduce.schema.save",
+        json={
+            "fields": [
+                {"field_id": "name", "label": "Name"},
+                {"field_id": "name", "label": "Duplicate"},
+            ]
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 400
+    body = resp.json()
+    assert body["ok"] is False
+    assert "audit_id" in body
+    assert "Duplicate field_id" in body["error"]


### PR DESCRIPTION
## Summary
- introduce a FastAPI-based management API with authentication helpers, request context, schemas, and audit-backed storage for all dashboard features
- expose the `/api/*` endpoints and health check via `src/nyaimlab/app.py` along with an executable entry point
- document the new backend, extend requirements, and add smoke tests that exercise welcome, guideline, and error flows

## Testing
- `pip install -r requirements.txt` *(fails: proxy prevents fetching fastapi package)*
- `pytest` *(fails: fastapi module missing because installation above could not run)*

------
https://chatgpt.com/codex/tasks/task_e_68cf1b5be39c832fae66a1527d6f9262