### PR TITLE
Add dashboard frontend and reorganize scrim management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,168 @@
-# ESCL Scrim Collector Discord Bot (Python)
+# Nyaimcat 管理スイート
 
-Collect 6 games of **ESCL** scrim "Detailed Results (copy)" text and export a single CSV (Google Sheets-friendly).
-Supports **text paste**, **file attachment (.txt/.tsv)**, and **URL (best-effort extraction)**.
+Nyaimcat リポジトリは Discord 上でのスクリム運営を支援する 3 つのコンポーネントから構成されています。
 
-## Quick Start
+- **ESCL Scrim Collector Bot** – `/escl_*` コマンドで ESCL の詳細結果を収集して CSV にまとめます。
+- **Nyaimlab Management API** – FastAPI 製の管理バックエンド。GitHub Pages からのダッシュボード呼び出しを受け付けます。
+- **Pages フロントエンド** – `docs/` 以下の静的 SPA。すべての管理項目をブラウザから編集できます。
 
-1) Python 3.10+ recommended
-2) Install deps
+## ディレクトリ構成
+
+```
+├─ src/esclbot/        # スクリム集計 Bot のコード
+├─ src/nyaimlab/       # FastAPI 管理 API
+├─ docs/               # GitHub Pages 用ダッシュボード (ビルド済み)
+├─ tests/              # FastAPI 向けテスト
+└─ requirements.txt    # 共通 Python 依存関係
+```
+
+---
+
+## 1. ESCL Scrim Collector Bot
+
+### セットアップ
+
+1. 依存関係をインストールします。
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. `.env` を用意して Discord Bot Token などを設定します。
+   ```bash
+   cp .env.example .env
+   # DISCORD_TOKEN や DEFAULT_SCRIM_GROUP を記入
+   ```
+3. Bot を起動します。
+   ```bash
+   python -m src.esclbot.bot
+   ```
+
+### 主なスラッシュコマンド
+
+| コマンド | 説明 |
+| --- | --- |
+| `/escl_new` | 新しい集計セッションを開始します。 |
+| `/escl_add` | URL / テキスト / ファイルから 1 試合分を追加します。 |
+| `/escl_list` | 取り込み状況を表示します。 |
+| `/escl_clear` | セッションを破棄して再開します。 |
+| `/escl_finish` | 取り込んだデータを 1 つの CSV として出力します。 |
+| `/escl_from_parent` | 親ページ URL だけで GAME1〜6 を自動収集します。 |
+| `/escl_from_urls` | ゲーム URL を複数指定してまとめて CSV を生成します。 |
+
+> ⚠️ URL からの抽出はベストエフォートです。失敗した場合は ESCL サイトの「詳細な試合結果をコピー」テキストを貼り付けてください。
+
+### 出力仕様
+
+- ESCL テーブルと互換性のあるヘッダーを持つ 1 つの CSV を生成します。
+  - メタ情報として `scrim_group`, `scrim_id`, `game_no` を付与します。
+- 文字コードは UTF-8。Google スプレッドシートでそのまま読み込めます。
+
+### デプロイメモ
+
+- ローカル実行: 上記コマンドで起動します。
+- Docker 化: シンプルな Dockerfile を追加して利用することもできます（必要に応じて PR を歓迎します）。
+
+内部では `src/esclbot/collector.py` がセッション管理と CSV 出力を統一的に処理します。
+
+---
+
+## 2. Nyaimlab Management API (FastAPI)
+
+GitHub Pages 上のダッシュボードからの設定変更はすべて FastAPI バックエンドを経由します。`API_AUTH_TOKEN` を使った Bearer 認証と、`x-client` / `x-guild-id` / `x-user-id` ヘッダーによる監査を必須としています。
+
+### 起動
+
+```bash
+export API_AUTH_TOKEN="your-pages-token"
+pip install -r requirements.txt
+python -m src.nyaimlab
+```
+
+既定では `0.0.0.0:8080` で起動します。`/api` 以下に以下の主なエンドポイントを提供します。
+
+- `POST /api/welcome.post` – Welcome Embed の保存
+- `POST /api/guideline.save` / `test` – ガイドライン DM の管理とプレビュー
+- `POST /api/verify.post` / `remove` – `/verify` メッセージの設置/削除
+- `POST /api/roles.*` – ロール配布設定、絵文字マッピング、プレビュー
+- `POST /api/introduce.*` – `/introduce` 投稿先とモーダル項目の管理
+- `POST /api/scrims.*` – 週間スクリム設定と手動実行
+- `POST /api/audit.*` – 監査ログ検索・エクスポート
+- `POST /api/settings.save` – 共通設定（言語・タイムゾーン等）
+- `POST /api/state.snapshot` – 現在のギルド設定と監査ログ抜粋を取得
+
+すべての応答は `{"ok": boolean, "error"?, "data"?, "audit_id"?}` 形式で返されます。`tests/test_nyaimlab_api.py` で主要なフローを確認できます。
+
+---
+
+## 3. GitHub Pages ダッシュボード
+
+`docs/` ディレクトリは管理用 SPA の完成ファイルです。GitHub Pages の公開対象を `main` ブランチの `docs/` に設定するだけで稼働します。
+
+### ローカルプレビュー
+
+```bash
+python -m http.server --directory docs 4173
+# http://localhost:4173 をブラウザで開く
+```
+
+ブラウザ上の [接続] タブで API Base URL、セッショントークン、ギルド ID、オペレーター ID を保存すると、以降すべての設定を GUI から編集できます。各ページは保存成功時に監査ログへ記録され、`監査ログ` タブから検索・エクスポートが可能です。
+
+### GitHub Pages への公開手順
+
+1. GitHub リポジトリの **Settings → Pages** で Source に `main` / `docs` を選択。
+2. 数分後に公開 URL が発行されます。ダッシュボードはバックエンドの `API_BASE_URL` と `API_AUTH_TOKEN` を参照して動作します。
+3. バックエンドは HTTPS で公開し、CORS 設定に Pages のドメイン (例: `https://<user>.github.io`) を追加してください。
+
+---
+
+## テスト
+
+管理 API のテストは `pytest` で実行できます。
+
 ```bash
 pip install -r requirements.txt
-```
-3) Create `.env` from example and set your token
-```bash
-cp .env.example .env
-# edit .env to put DISCORD_TOKEN=...
-```
-4) Run the bot
-```bash
-python -m src.esclbot.bot
+pytest
 ```
 
-## Slash Commands
+---
 
-- `/escl_new [scrim_group] [scrim_url]` — start a session (per guild/channel/user)
-- `/escl_add [url] [text] [file]` — add one game by **URL**, **text**, or **attachment** (choose one)
-- `/escl_list` — show progress
-- `/escl_clear` — clear the current session
-- `/escl_finish` — when 6 games are added, export a single CSV
+## Appendix: English Quick Reference
 
-> The bot prioritizes **text paste** reliability. URL extraction is best-effort and may fall back to asking for the copied text.
+### Quick Start
 
-## Output
-- A single CSV with headers matching ESCL’s table, plus meta columns:
-  - `scrim_group`, `scrim_id`, `game_no`
-- UTF-8 with headers row; opens cleanly in Google Sheets.
+1. Python 3.10+ is recommended.
+2. Install dependencies
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Copy `.env.example` to `.env` and set `DISCORD_TOKEN` (and other options).
+4. Run the bot
+   ```bash
+   python -m src.esclbot.bot
+   ```
 
-## Deploy
-- Local: run the module as above
-- Docker (optional): you can add a simple Dockerfile; PRs welcome
+### Slash Commands
+
+- `/escl_new [scrim_group] [scrim_url]` — start a session scoped by guild/channel/user
+- `/escl_add [url|text|file]` — ingest one game from a URL, pasted text or attachment
+- `/escl_list`, `/escl_clear`, `/escl_finish`
+- `/escl_from_parent`, `/escl_from_urls` — full automation helpers
+
+> The bot prioritises **text paste** reliability. URL extraction is best-effort and may fall back to the copied text.
+
+### Output & Deploy
+
+- One UTF-8 CSV containing the ESCL headers plus `scrim_group`, `scrim_id`, `game_no`.
+- Local deploy: run the module as above.
+- Docker: feel free to add a Dockerfile in your own environment.
+
+### Management API recap
+
+- Start locally with `python -m src.nyaimlab` after setting `API_AUTH_TOKEN`.
+- Every request must provide `Authorization`, `x-client`, `x-guild-id`, `x-user-id` headers.
+- Implemented routes include welcome, guideline, verify, roles, introduce, scrims, audit, settings and `state.snapshot`. Responses follow `{"ok", "error"?, "data"?, "audit_id"?}`.
+
+---
+
+## ライセンス
+
+このリポジトリはプロジェクトメンバー向けに提供されており、利用条件は別途合意に従います。

--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -1,0 +1,89 @@
+import { DashboardState } from "./state.js";
+import { clear, el, showToast } from "./ui.js";
+import { renderHome } from "./pages/home.js";
+import { renderWelcome } from "./pages/welcome.js";
+import { renderGuideline } from "./pages/guideline.js";
+import { renderVerify } from "./pages/verify.js";
+import { renderRoles } from "./pages/roles.js";
+import { renderIntroduce } from "./pages/introduce.js";
+import { renderScrims } from "./pages/scrims.js";
+import { renderAudit } from "./pages/audit.js";
+import { renderSettings } from "./pages/settings.js";
+
+const state = new DashboardState();
+
+const routes = [
+  { path: "#/home", label: "接続", render: renderHome },
+  { path: "#/welcome", label: "Welcome", render: renderWelcome },
+  { path: "#/guideline", label: "ガイドラインDM", render: renderGuideline },
+  { path: "#/verify", label: "Verify", render: renderVerify },
+  { path: "#/roles", label: "ロール配布", render: renderRoles },
+  { path: "#/introduce", label: "自己紹介", render: renderIntroduce },
+  { path: "#/scrims", label: "スクリム", render: renderScrims },
+  { path: "#/audit", label: "監査ログ", render: renderAudit },
+  { path: "#/settings", label: "共通設定", render: renderSettings },
+];
+
+const routeMap = new Map(routes.map((route) => [route.path, route]));
+
+function ensureHash() {
+  if (!window.location.hash) {
+    window.location.hash = "#/home";
+  }
+}
+
+function renderNav() {
+  const nav = document.getElementById("nav");
+  clear(nav);
+  routes.forEach((route) => {
+    const link = el(
+      "a",
+      {
+        href: route.path,
+        className: "nav-link",
+      },
+      route.label,
+    );
+    nav.appendChild(link);
+  });
+}
+
+function highlightNav(hash) {
+  const nav = document.getElementById("nav");
+  nav.querySelectorAll("a").forEach((anchor) => {
+    if (anchor.getAttribute("href") === hash) {
+      anchor.classList.add("active");
+    } else {
+      anchor.classList.remove("active");
+    }
+  });
+}
+
+async function renderRoute() {
+  ensureHash();
+  const hash = window.location.hash;
+  const route = routeMap.get(hash) || routes[0];
+  highlightNav(route.path);
+
+  const root = document.getElementById("app");
+  clear(root);
+
+  try {
+    await route.render({ state, root, showToast });
+  } catch (error) {
+    console.error(error);
+    const panel = el("section", { className: "panel error" });
+    panel.appendChild(el("h2", { textContent: "エラー" }));
+    panel.appendChild(el("p", { textContent: error.message || "処理中に問題が発生しました。" }));
+    root.appendChild(panel);
+  }
+}
+
+window.addEventListener("hashchange", () => {
+  renderRoute().catch((error) => console.error("render failed", error));
+});
+
+document.addEventListener("DOMContentLoaded", () => {
+  renderNav();
+  renderRoute().catch((error) => console.error("render failed", error));
+});

--- a/docs/assets/pages/audit.js
+++ b/docs/assets/pages/audit.js
@@ -1,0 +1,132 @@
+import {
+  createButton,
+  createSection,
+  el,
+  ensureSnapshot,
+  formField,
+  select,
+  textInput,
+  textarea,
+  toggleLoading,
+} from "../ui.js";
+
+function renderTable(rows = []) {
+  const wrapper = el("div", { className: "table-scroll" });
+  if (!rows.length) {
+    wrapper.append(el("p", { textContent: "結果はありません。" }));
+    return wrapper;
+  }
+  const table = el("table");
+  const thead = el("thead");
+  const headerRow = el("tr");
+  ["timestamp", "action", "ok", "actor_id", "channel_id", "error"].forEach((col) => {
+    headerRow.append(el("th", { textContent: col }));
+  });
+  thead.append(headerRow);
+  table.append(thead);
+  const tbody = el("tbody");
+  rows.forEach((row) => {
+    const tr = el("tr");
+    headerRow.childNodes.forEach((th) => {
+      const key = th.textContent;
+      tr.append(el("td", { textContent: row[key] ?? "" }));
+    });
+    tbody.append(tr);
+  });
+  table.append(tbody);
+  wrapper.append(table);
+  return wrapper;
+}
+
+export async function renderAudit({ state, root, showToast }) {
+  const snapshot = await ensureSnapshot(state, root).catch(() => null);
+  if (!snapshot) {
+    return;
+  }
+
+  const recentSection = createSection("最近の監査", "最新のイベントを表示します。最大50件。");
+  recentSection.append(renderTable(snapshot.audit_recent || []));
+
+  const searchSection = createSection("監査検索");
+  const searchForm = el("form");
+  const sinceInput = textInput({ type: "datetime-local" });
+  const untilInput = textInput({ type: "datetime-local" });
+  const actionInput = textInput({ value: "", placeholder: "アクション" });
+  const userInput = textInput({ value: "", placeholder: "ユーザーID" });
+  const channelInput = textInput({ value: "", placeholder: "チャンネルID" });
+  const limitInput = textInput({ type: "number", value: 50, placeholder: "最大件数" });
+  const resultsContainer = el("div");
+
+  searchForm.append(
+    formField("開始日時", sinceInput),
+    formField("終了日時", untilInput),
+    formField("アクション", actionInput),
+    formField("ユーザーID", userInput),
+    formField("チャンネルID", channelInput),
+    formField("件数", limitInput),
+    el("div", { className: "inline-actions" }, createButton("検索", { type: "submit" })),
+    resultsContainer,
+  );
+
+  searchForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const payload = {
+      since: sinceInput.value ? new Date(sinceInput.value).toISOString() : null,
+      until: untilInput.value ? new Date(untilInput.value).toISOString() : null,
+      action: actionInput.value.trim() || null,
+      user_id: userInput.value.trim() || null,
+      channel_id: channelInput.value.trim() || null,
+      limit: Number(limitInput.value) || 50,
+    };
+
+    toggleLoading(searchForm, true);
+    try {
+      const data = await state.request("/api/audit.search", payload);
+      resultsContainer.innerHTML = "";
+      resultsContainer.append(renderTable(data.results || []));
+    } catch (error) {
+      showToast(error.message || "検索に失敗しました。", "error");
+    } finally {
+      toggleLoading(searchForm, false);
+    }
+  });
+
+  searchSection.append(searchForm);
+
+  const exportSection = createSection("エクスポート");
+  const exportForm = el("form");
+  const formatSelect = select({
+    value: "ndjson",
+    options: [
+      { value: "ndjson", label: "NDJSON" },
+      { value: "csv", label: "CSV" },
+    ],
+  });
+  const exportArea = textarea({ value: "", rows: 8, placeholder: "エクスポート結果" });
+  exportForm.append(
+    formField("フォーマット", formatSelect),
+    el("div", { className: "inline-actions" }, createButton("エクスポート", { type: "submit" })),
+    exportArea,
+  );
+
+  exportForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    toggleLoading(exportForm, true);
+    try {
+      const payload = {
+        format: formatSelect.value,
+      };
+      const data = await state.request("/api/audit.export", payload);
+      exportArea.value = data.content || "";
+      showToast("エクスポートが完了しました。", "success");
+    } catch (error) {
+      showToast(error.message || "エクスポートに失敗しました。", "error");
+    } finally {
+      toggleLoading(exportForm, false);
+    }
+  });
+
+  exportSection.append(exportForm);
+
+  root.append(recentSection, searchSection, exportSection);
+}

--- a/docs/assets/pages/guideline.js
+++ b/docs/assets/pages/guideline.js
@@ -1,0 +1,126 @@
+import {
+  clear,
+  createButton,
+  createSection,
+  el,
+  ensureSnapshot,
+  formField,
+  textInput,
+  textarea,
+  toggleLoading,
+} from "../ui.js";
+
+function createAttachmentRow(container, initial = "") {
+  const row = el("div", { className: "attachment-row" });
+  const input = textInput({ type: "url", value: initial, placeholder: "https://assets.example" });
+  row.append(formField("添付URL", input));
+  const removeBtn = createButton("削除", { variant: "secondary" });
+  removeBtn.addEventListener("click", () => row.remove());
+  row.append(el("div", { className: "inline-actions" }, removeBtn));
+  container.append(row);
+}
+
+export async function renderGuideline({ state, root, showToast }) {
+  const snapshot = await ensureSnapshot(state, root).catch(() => null);
+  if (!snapshot) {
+    return;
+  }
+
+  const template = snapshot.guideline || { content: "", attachments: [] };
+
+  const section = createSection("ガイドラインDM", "入室時に送るDMテンプレートを編集します。");
+  const form = el("form");
+  const contentArea = textarea({ value: template.content || "", rows: 10, placeholder: "DMに送る本文" });
+  const attachmentsContainer = el("div", { className: "attachment-list" });
+  (template.attachments || []).forEach((url) => createAttachmentRow(attachmentsContainer, url));
+  if (!attachmentsContainer.childElementCount) {
+    createAttachmentRow(attachmentsContainer);
+  }
+  const addAttachmentButton = createButton("添付URLを追加", { variant: "secondary" });
+  addAttachmentButton.addEventListener("click", () => createAttachmentRow(attachmentsContainer));
+
+  form.append(
+    formField("DM本文", contentArea, "Markdown を含むテキストを入力します"),
+    attachmentsContainer,
+    el("div", { className: "inline-actions" }, addAttachmentButton),
+  );
+
+  const submitButton = createButton("テンプレートを保存", { type: "submit" });
+  form.append(el("div", { className: "inline-actions" }, submitButton));
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const attachments = [];
+    attachmentsContainer.querySelectorAll("input[type='url']").forEach((input) => {
+      const value = input.value.trim();
+      if (value) {
+        attachments.push(value);
+      }
+    });
+
+    const payload = {
+      content: contentArea.value.trim(),
+      attachments,
+    };
+
+    toggleLoading(form, true);
+    try {
+      const data = await state.request("/api/guideline.save", payload);
+      if (data.template) {
+        state.updateSnapshot("guideline", data.template);
+      }
+      showToast("ガイドラインを保存しました。", "success");
+      clear(root);
+      await renderGuideline({ state, root, showToast });
+    } catch (error) {
+      showToast(error.message || "保存に失敗しました。", "error");
+    } finally {
+      toggleLoading(form, false);
+    }
+  });
+
+  section.append(form);
+
+  const testSection = createSection("プレビュー送信");
+  const testForm = el("form");
+  const targetInput = textInput({ value: "", placeholder: "DiscordユーザーID (任意)" });
+  const dryRunToggle = el("input", { type: "checkbox" });
+  dryRunToggle.checked = true;
+  const dryRunField = formField(
+    "Dry-run",
+    dryRunToggle,
+    "チェックしたままなら実際には送信しません",
+  );
+
+  const previewArea = el("pre", { textContent: "" });
+
+  testForm.append(
+    formField("対象ユーザー", targetInput, "省略するとサーバー側のダミーIDで検証します"),
+    dryRunField,
+    el("div", { className: "inline-actions" }, createButton("テストリクエスト", { type: "submit" })),
+    previewArea,
+  );
+
+  testForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const payload = {
+      target_user_id: targetInput.value.trim() || null,
+      dry_run: dryRunToggle.checked,
+    };
+
+    toggleLoading(testForm, true);
+    try {
+      const data = await state.request("/api/guideline.test", payload);
+      previewArea.textContent = JSON.stringify(data.preview, null, 2);
+      showToast("テストリクエストを送信しました。", "success");
+    } catch (error) {
+      showToast(error.message || "テストに失敗しました。", "error");
+    } finally {
+      toggleLoading(testForm, false);
+    }
+  });
+
+  testSection.append(testForm);
+
+  root.append(section, testSection);
+}

--- a/docs/assets/pages/home.js
+++ b/docs/assets/pages/home.js
@@ -1,0 +1,101 @@
+import {
+  clear,
+  createButton,
+  createSection,
+  formField,
+  el,
+  textInput,
+  toggleLoading,
+} from "../ui.js";
+
+export async function renderHome({ state, root, showToast }) {
+  const section = createSection("API接続", "FastAPI 管理バックエンドへの接続情報を設定します。");
+  const form = el("form", { className: "connection-form" });
+
+  const baseUrlInput = textInput({
+    type: "url",
+    value: state.apiBaseUrl,
+    placeholder: "https://example.com",
+  });
+  const tokenInput = textInput({ type: "password", value: state.sessionToken });
+  const guildInput = textInput({ value: state.guildId, placeholder: "1234567890", required: true });
+  const actorInput = textInput({ value: state.actorId, placeholder: "操作者のDiscord ID", required: true });
+  const clientInput = textInput({ value: state.clientId, placeholder: "pages-dashboard" });
+
+  form.append(
+    formField("API Base URL", baseUrlInput, "FastAPI が動作しているホストのURL"),
+    formField("セッショントークン", tokenInput, "Bearer 認証に利用されるAPIトークン"),
+    formField("Guild ID", guildInput, "操作対象のギルドID"),
+    formField("Operator User ID", actorInput, "監査ログに記録される操作者"),
+    formField("Client ID", clientInput, "x-client ヘッダーに利用"),
+  );
+
+  const actions = el("div", { className: "inline-actions" });
+  const saveButton = createButton("接続情報を保存", { type: "submit" });
+  const reloadButton = createButton("サーバーから設定を取得", { variant: "secondary" });
+
+  actions.append(saveButton, reloadButton);
+  form.append(actions);
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    state.updateConnection({
+      apiBaseUrl: baseUrlInput.value,
+      sessionToken: tokenInput.value,
+      guildId: guildInput.value,
+      actorId: actorInput.value,
+      clientId: clientInput.value,
+    });
+    state.clearSnapshot();
+    showToast("接続情報を保存しました。", "success");
+  });
+
+  reloadButton.addEventListener("click", async () => {
+    if (!state.isReady()) {
+      showToast("接続情報を先に入力してください。", "error");
+      return;
+    }
+    toggleLoading(section, true);
+    try {
+      await state.pullSnapshot();
+      showToast("設定を再読み込みしました。", "success");
+    } catch (error) {
+      showToast(error.message || "設定の取得に失敗しました。", "error");
+    } finally {
+      toggleLoading(section, false);
+      clear(root);
+      await renderHome({ state, root, showToast });
+    }
+  });
+
+  section.append(form);
+  root.append(section);
+
+  const statusPanel = createSection("現在の状態");
+  const statusList = el("ul");
+  statusList.append(
+    el("li", {}, state.isReady() ? "APIに接続できます" : "API接続が未設定です"),
+    el("li", {}, state.snapshot ? "サーバー設定を読み込み済み" : "サーバー設定は未取得です"),
+  );
+  statusPanel.append(statusList);
+
+  if (state.snapshot) {
+    const summary = el("div", { className: "summary-grid" });
+    const sections = [
+      ["Welcome", state.snapshot.welcome ? "設定済み" : "未設定"],
+      ["ガイドラインDM", state.snapshot.guideline ? "設定済み" : "未設定"],
+      ["Verify", state.snapshot.verify ? "設定済み" : "未設定"],
+      ["ロール配布", state.snapshot.roles ? `${state.snapshot.roles.roles?.length || 0} 件` : "未設定"],
+      ["自己紹介", state.snapshot.introduce ? "設定済み" : "未設定"],
+      ["スクリム", state.snapshot.scrims ? "設定済み" : "未設定"],
+    ];
+    sections.forEach(([title, value]) => {
+      const card = el("div", { className: "summary-card" });
+      card.append(el("h3", { textContent: title }), el("p", { textContent: value }));
+      summary.append(card);
+    });
+    statusPanel.append(summary);
+  }
+
+  root.append(statusPanel);
+}

--- a/docs/assets/pages/introduce.js
+++ b/docs/assets/pages/introduce.js
@@ -1,0 +1,172 @@
+import {
+  clear,
+  createButton,
+  createSection,
+  el,
+  ensureSnapshot,
+  formField,
+  textInput,
+  textarea,
+  toggleLoading,
+} from "../ui.js";
+
+const defaultIntroduce = {
+  channel_id: "",
+  mention_role_ids: [],
+  embed_title: "自己紹介",
+  footer_text: "",
+};
+
+function createFieldRow(container, initial = {}) {
+  const row = el("div", { className: "field-row" });
+  const idInput = textInput({ value: initial.field_id || "", placeholder: "field_id" });
+  idInput.dataset.field = "field_id";
+  const labelInput = textInput({ value: initial.label || "", placeholder: "ラベル" });
+  labelInput.dataset.field = "label";
+  const placeholderInput = textInput({ value: initial.placeholder || "", placeholder: "プレースホルダー" });
+  placeholderInput.dataset.field = "placeholder";
+  const requiredInput = el("input", { type: "checkbox" });
+  requiredInput.checked = initial.required !== undefined ? initial.required : true;
+  requiredInput.dataset.field = "required";
+  const enabledInput = el("input", { type: "checkbox" });
+  enabledInput.checked = initial.enabled !== undefined ? initial.enabled : true;
+  enabledInput.dataset.field = "enabled";
+  const maxLengthInput = textInput({ type: "number", value: initial.max_length ?? 300, placeholder: "最大文字数" });
+  maxLengthInput.dataset.field = "max_length";
+
+  row.append(
+    formField("フィールドID", idInput),
+    formField("ラベル", labelInput),
+    formField("プレースホルダー", placeholderInput),
+    formField("必須", requiredInput),
+    formField("有効", enabledInput),
+    formField("最大文字数", maxLengthInput),
+  );
+
+  const removeBtn = createButton("削除", { variant: "secondary" });
+  removeBtn.addEventListener("click", () => row.remove());
+  row.append(el("div", { className: "inline-actions" }, removeBtn));
+  container.append(row);
+}
+
+export async function renderIntroduce({ state, root, showToast }) {
+  const snapshot = await ensureSnapshot(state, root).catch(() => null);
+  if (!snapshot) {
+    return;
+  }
+
+  const config = { ...defaultIntroduce, ...(snapshot.introduce || {}) };
+  const schema = snapshot.introduce_schema || { fields: [] };
+
+  const configSection = createSection("自己紹介投稿", "自己紹介メッセージの投稿先と装飾を設定します。");
+  const configForm = el("form");
+  const channelInput = textInput({ value: config.channel_id || "", placeholder: "チャンネルID", required: true });
+  const mentionInput = textarea({
+    value: (config.mention_role_ids || []).join("\n"),
+    rows: 3,
+    placeholder: "メンションしたいロールIDを1行ずつ",
+  });
+  const titleInput = textInput({ value: config.embed_title || defaultIntroduce.embed_title });
+  const footerInput = textInput({ value: config.footer_text || "", placeholder: "フッター (任意)" });
+
+  configForm.append(
+    formField("投稿チャンネルID", channelInput),
+    formField("メンションするロールID", mentionInput, "複数行で指定すると順番にメンションします"),
+    formField("Embedタイトル", titleInput),
+    formField("フッター", footerInput),
+    el("div", { className: "inline-actions" }, createButton("保存", { type: "submit" })),
+  );
+
+  configForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const mentionRoleIds = mentionInput.value
+      .split(/\r?\n|,/)
+      .map((v) => v.trim())
+      .filter(Boolean);
+
+    const payload = {
+      channel_id: channelInput.value.trim(),
+      mention_role_ids: mentionRoleIds,
+      embed_title: titleInput.value.trim() || defaultIntroduce.embed_title,
+      footer_text: footerInput.value.trim() || null,
+    };
+
+    toggleLoading(configForm, true);
+    try {
+      const data = await state.request("/api/introduce.post", payload);
+      if (data.config) {
+        state.updateSnapshot("introduce", data.config);
+      }
+      showToast("自己紹介設定を保存しました。", "success");
+      clear(root);
+      await renderIntroduce({ state, root, showToast });
+    } catch (error) {
+      showToast(error.message || "保存に失敗しました。", "error");
+    } finally {
+      toggleLoading(configForm, false);
+    }
+  });
+
+  configSection.append(configForm);
+
+  const schemaSection = createSection("モーダル項目", "自己紹介フォームの項目を編集します。");
+  const schemaForm = el("form");
+  const fieldsContainer = el("div", { className: "field-list" });
+  (schema.fields || []).forEach((field) => createFieldRow(fieldsContainer, field));
+  if (!fieldsContainer.childElementCount) {
+    createFieldRow(fieldsContainer);
+  }
+  const addFieldBtn = createButton("項目を追加", { variant: "secondary" });
+  addFieldBtn.addEventListener("click", () => createFieldRow(fieldsContainer));
+
+  schemaForm.append(fieldsContainer, el("div", { className: "inline-actions" }, addFieldBtn));
+  schemaForm.append(el("div", { className: "inline-actions" }, createButton("スキーマを保存", { type: "submit" })));
+
+  schemaForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const fields = [];
+    fieldsContainer.querySelectorAll(".field-row").forEach((row) => {
+      const fieldId = row.querySelector('[data-field="field_id"]').value.trim();
+      const label = row.querySelector('[data-field="label"]').value.trim();
+      if (!fieldId || !label) {
+        return;
+      }
+      const placeholder = row.querySelector('[data-field="placeholder"]').value.trim();
+      const required = row.querySelector('[data-field="required"]').checked;
+      const enabled = row.querySelector('[data-field="enabled"]').checked;
+      const maxLength = Number(row.querySelector('[data-field="max_length"]').value) || 300;
+      const entry = {
+        field_id: fieldId,
+        label,
+        required,
+        enabled,
+        max_length: maxLength,
+      };
+      if (placeholder) {
+        entry.placeholder = placeholder;
+      }
+      fields.push(entry);
+    });
+
+    const payload = { fields };
+
+    toggleLoading(schemaForm, true);
+    try {
+      const data = await state.request("/api/introduce.schema.save", payload);
+      if (data.schema) {
+        state.updateSnapshot("introduce_schema", data.schema);
+      }
+      showToast("スキーマを保存しました。", "success");
+      clear(root);
+      await renderIntroduce({ state, root, showToast });
+    } catch (error) {
+      showToast(error.message || "保存に失敗しました。", "error");
+    } finally {
+      toggleLoading(schemaForm, false);
+    }
+  });
+
+  schemaSection.append(schemaForm);
+
+  root.append(configSection, schemaSection);
+}

--- a/docs/assets/pages/roles.js
+++ b/docs/assets/pages/roles.js
@@ -1,0 +1,251 @@
+import {
+  clear,
+  createButton,
+  createSection,
+  el,
+  ensureSnapshot,
+  formField,
+  select,
+  textInput,
+  textarea,
+  toggleLoading,
+} from "../ui.js";
+
+const defaultRoles = {
+  channel_id: "",
+  style: "buttons",
+  message_content: "",
+  roles: [],
+};
+
+function createRoleRow(container, initial = {}) {
+  const row = el("div", { className: "role-row" });
+  const roleIdInput = textInput({ value: initial.role_id || "", placeholder: "ロールID" });
+  roleIdInput.dataset.field = "role_id";
+  const labelInput = textInput({ value: initial.label || "", placeholder: "表示名" });
+  labelInput.dataset.field = "label";
+  const descInput = textInput({ value: initial.description || "", placeholder: "説明 (任意)" });
+  descInput.dataset.field = "description";
+  const emojiInput = textInput({ value: initial.emoji || "", placeholder: "Emoji (任意)" });
+  emojiInput.dataset.field = "emoji";
+  const hiddenInput = el("input", { type: "checkbox" });
+  hiddenInput.checked = Boolean(initial.hidden);
+  hiddenInput.dataset.field = "hidden";
+  const sortInput = textInput({ type: "number", value: initial.sort_order ?? 0, placeholder: "並び順" });
+  sortInput.dataset.field = "sort_order";
+
+  row.append(
+    formField("ロールID", roleIdInput),
+    formField("表示名", labelInput),
+    formField("説明", descInput),
+    formField("絵文字", emojiInput),
+    formField("非表示", hiddenInput),
+    formField("並び順", sortInput),
+  );
+
+  const removeBtn = createButton("削除", { variant: "secondary" });
+  removeBtn.addEventListener("click", () => row.remove());
+  row.append(el("div", { className: "inline-actions" }, removeBtn));
+  container.append(row);
+}
+
+export async function renderRoles({ state, root, showToast }) {
+  const snapshot = await ensureSnapshot(state, root).catch(() => null);
+  if (!snapshot) {
+    return;
+  }
+
+  const config = { ...defaultRoles, ...(snapshot.roles || {}) };
+
+  const section = createSection("ロール配布", "ボタン/メニュー/リアクションで付与するロールを編集します。");
+  const form = el("form");
+  const channelInput = textInput({ value: config.channel_id || "", placeholder: "チャンネルID", required: true });
+  const styleSelect = select({
+    value: config.style || "buttons",
+    options: [
+      { value: "buttons", label: "ボタン" },
+      { value: "select", label: "セレクトメニュー" },
+      { value: "reactions", label: "リアクション" },
+    ],
+  });
+  const messageContentArea = textarea({ value: config.message_content || "", rows: 3, placeholder: "任意の説明文" });
+
+  form.append(
+    formField("投稿チャンネルID", channelInput),
+    formField("UIスタイル", styleSelect),
+    formField("メッセージ本文", messageContentArea, "空欄なら既定の案内文が使用されます"),
+  );
+
+  const rolesContainer = el("div", { className: "role-list" });
+  (config.roles || []).forEach((role) => createRoleRow(rolesContainer, role));
+  if (!rolesContainer.childElementCount) {
+    createRoleRow(rolesContainer);
+  }
+  const addRoleBtn = createButton("ロールを追加", { variant: "secondary" });
+  addRoleBtn.addEventListener("click", () => createRoleRow(rolesContainer));
+
+  form.append(rolesContainer, el("div", { className: "inline-actions" }, addRoleBtn));
+
+  const submitButton = createButton("ロール設定を保存", { type: "submit" });
+  form.append(el("div", { className: "inline-actions" }, submitButton));
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const payload = {
+      channel_id: channelInput.value.trim(),
+      style: styleSelect.value,
+      message_content: messageContentArea.value.trim() || null,
+      roles: [],
+    };
+
+    rolesContainer.querySelectorAll(".role-row").forEach((row) => {
+      const roleId = row.querySelector('[data-field="role_id"]').value.trim();
+      const label = row.querySelector('[data-field="label"]').value.trim();
+      if (!roleId || !label) {
+        return;
+      }
+      const description = row.querySelector('[data-field="description"]').value.trim();
+      const emoji = row.querySelector('[data-field="emoji"]').value.trim();
+      const hidden = row.querySelector('[data-field="hidden"]').checked;
+      const sortValue = row.querySelector('[data-field="sort_order"]').value;
+      const entry = {
+        role_id: roleId,
+        label,
+        hidden,
+        sort_order: Number(sortValue) || 0,
+      };
+      if (description) {
+        entry.description = description;
+      }
+      if (emoji) {
+        entry.emoji = emoji;
+      }
+      payload.roles.push(entry);
+    });
+
+    toggleLoading(form, true);
+    try {
+      const data = await state.request("/api/roles.post", payload);
+      if (data.config) {
+        state.updateSnapshot("roles", data.config);
+      }
+      showToast("ロール設定を保存しました。", "success");
+      clear(root);
+      await renderRoles({ state, root, showToast });
+    } catch (error) {
+      showToast(error.message || "保存に失敗しました。", "error");
+    } finally {
+      toggleLoading(form, false);
+    }
+  });
+
+  section.append(form);
+
+  const emojiSection = createSection("リアクション絵文字対応");
+  const mapForm = el("form");
+  const emojiRoleId = textInput({ value: "", placeholder: "ロールID" });
+  const emojiValue = textInput({ value: "", placeholder: "emoji または :custom:" });
+  mapForm.append(
+    formField("ロールID", emojiRoleId),
+    formField("絵文字", emojiValue, "空欄にすると対応付けを削除します"),
+    el("div", { className: "inline-actions" }, createButton("保存", { type: "submit" })),
+  );
+
+  mapForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const payload = {
+      role_id: emojiRoleId.value.trim(),
+      emoji: emojiValue.value.trim() || null,
+    };
+    if (!payload.role_id) {
+      showToast("ロールIDを入力してください。", "error");
+      return;
+    }
+
+    toggleLoading(mapForm, true);
+    try {
+      const data = await state.request("/api/roles.mapEmoji", payload);
+      state.updateSnapshot("role_emoji_map", data.mapping);
+      showToast("絵文字マッピングを更新しました。", "success");
+    } catch (error) {
+      showToast(error.message || "更新に失敗しました。", "error");
+    } finally {
+      toggleLoading(mapForm, false);
+    }
+  });
+
+  emojiSection.append(mapForm);
+
+  const currentMap = state.snapshot?.role_emoji_map || {};
+  const mapEntries = Object.entries(currentMap);
+  if (mapEntries.length) {
+    const list = el("ul");
+    mapEntries.forEach(([roleId, emoji]) => {
+      list.append(el("li", {}, `${roleId}: ${emoji}`));
+    });
+    emojiSection.append(list);
+  }
+
+  const removeSection = createSection("ロール設定の削除");
+  const removeForm = el("form");
+  const removeInput = textInput({ value: "", placeholder: "ロールID (空欄で全削除)" });
+  removeForm.append(
+    formField("削除対象", removeInput, "特定ロールIDを入力するとその行だけ削除します"),
+    el("div", { className: "inline-actions" }, createButton("削除", { type: "submit", variant: "danger" })),
+  );
+
+  removeForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const payload = { role_id: removeInput.value.trim() || null };
+    toggleLoading(removeForm, true);
+    try {
+      const data = await state.request("/api/roles.remove", payload);
+      state.updateSnapshot("roles", data.config || null);
+      if (!payload.role_id) {
+        state.updateSnapshot("role_emoji_map", {});
+      }
+      showToast("ロール設定を更新しました。", "success");
+      clear(root);
+      await renderRoles({ state, root, showToast });
+    } catch (error) {
+      showToast(error.message || "削除に失敗しました。", "error");
+    } finally {
+      toggleLoading(removeForm, false);
+    }
+  });
+
+  removeSection.append(removeForm);
+
+  const previewSection = createSection("プレビュー");
+  const previewForm = el("form");
+  const localeSelect = select({
+    value: "ja-JP",
+    options: [
+      { value: "ja-JP", label: "日本語" },
+      { value: "en-US", label: "English" },
+    ],
+  });
+  const previewArea = el("pre", { textContent: "" });
+  previewForm.append(
+    formField("表示言語", localeSelect),
+    el("div", { className: "inline-actions" }, createButton("生成", { type: "submit" })),
+    previewArea,
+  );
+
+  previewForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    toggleLoading(previewForm, true);
+    try {
+      const data = await state.request("/api/roles.preview", { locale: localeSelect.value });
+      previewArea.textContent = JSON.stringify(data.preview, null, 2);
+    } catch (error) {
+      showToast(error.message || "プレビューに失敗しました。", "error");
+    } finally {
+      toggleLoading(previewForm, false);
+    }
+  });
+
+  previewSection.append(previewForm);
+
+  root.append(section, emojiSection, removeSection, previewSection);
+}

--- a/docs/assets/pages/scrims.js
+++ b/docs/assets/pages/scrims.js
@@ -1,0 +1,166 @@
+import {
+  clear,
+  createButton,
+  createSection,
+  el,
+  ensureSnapshot,
+  formField,
+  select,
+  textInput,
+  toggleLoading,
+} from "../ui.js";
+
+const defaultScrim = {
+  timezone: "Asia/Tokyo",
+  manager_role_id: "",
+  rules: [],
+};
+
+function createRuleRow(container, initial = {}) {
+  const row = el("div", { className: "rule-row" });
+  const daySelect = select({
+    value: initial.day || "sun",
+    options: [
+      { value: "sun", label: "日曜" },
+      { value: "mon", label: "月曜" },
+      { value: "tue", label: "火曜" },
+      { value: "wed", label: "水曜" },
+      { value: "thu", label: "木曜" },
+      { value: "fri", label: "金曜" },
+      { value: "sat", label: "土曜" },
+    ],
+  });
+  daySelect.dataset.field = "day";
+  const openInput = textInput({ type: "number", value: initial.survey_open_hour ?? 12, placeholder: "開始時刻" });
+  openInput.dataset.field = "survey_open_hour";
+  const closeInput = textInput({ type: "number", value: initial.survey_close_hour ?? 22, placeholder: "締切時刻" });
+  closeInput.dataset.field = "survey_close_hour";
+  const notifyInput = textInput({ value: initial.notify_channel_id || "", placeholder: "通知チャンネルID" });
+  notifyInput.dataset.field = "notify_channel_id";
+  const minMembersInput = textInput({ type: "number", value: initial.min_team_members ?? 3, placeholder: "必要メンバー" });
+  minMembersInput.dataset.field = "min_team_members";
+
+  row.append(
+    formField("曜日", daySelect),
+    formField("募集開始時刻", openInput),
+    formField("締切時刻", closeInput),
+    formField("通知チャンネルID", notifyInput),
+    formField("必要メンバー数", minMembersInput),
+  );
+
+  const removeBtn = createButton("削除", { variant: "secondary" });
+  removeBtn.addEventListener("click", () => row.remove());
+  row.append(el("div", { className: "inline-actions" }, removeBtn));
+  container.append(row);
+}
+
+export async function renderScrims({ state, root, showToast }) {
+  const snapshot = await ensureSnapshot(state, root).catch(() => null);
+  if (!snapshot) {
+    return;
+  }
+
+  const config = { ...defaultScrim, ...(snapshot.scrims || {}) };
+
+  const section = createSection("スクリム補助", "週間スクリム設定を管理します。");
+  const form = el("form");
+  const timezoneSelect = select({
+    value: config.timezone || "Asia/Tokyo",
+    options: [
+      { value: "Asia/Tokyo", label: "JST" },
+      { value: "UTC", label: "UTC" },
+    ],
+  });
+  const managerRoleInput = textInput({ value: config.manager_role_id || "", placeholder: "マネージャーロールID (任意)" });
+
+  form.append(
+    formField("タイムゾーン", timezoneSelect),
+    formField("マネージャーロールID", managerRoleInput),
+  );
+
+  const rulesContainer = el("div", { className: "rule-list" });
+  (config.rules || []).forEach((rule) => createRuleRow(rulesContainer, rule));
+  if (!rulesContainer.childElementCount) {
+    createRuleRow(rulesContainer);
+  }
+  const addRuleBtn = createButton("ルールを追加", { variant: "secondary" });
+  addRuleBtn.addEventListener("click", () => createRuleRow(rulesContainer));
+
+  form.append(rulesContainer, el("div", { className: "inline-actions" }, addRuleBtn));
+  form.append(el("div", { className: "inline-actions" }, createButton("設定を保存", { type: "submit" })));
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const rules = [];
+    rulesContainer.querySelectorAll(".rule-row").forEach((row) => {
+      const day = row.querySelector('[data-field="day"]').value;
+      const openHour = Number(row.querySelector('[data-field="survey_open_hour"]').value) || 0;
+      const closeHour = Number(row.querySelector('[data-field="survey_close_hour"]').value) || 0;
+      const notifyChannel = row.querySelector('[data-field="notify_channel_id"]').value.trim();
+      const minMembers = Number(row.querySelector('[data-field="min_team_members"]').value) || 3;
+      if (!notifyChannel) {
+        return;
+      }
+      rules.push({
+        day,
+        survey_open_hour: openHour,
+        survey_close_hour: closeHour,
+        notify_channel_id: notifyChannel,
+        min_team_members: minMembers,
+      });
+    });
+
+    const payload = {
+      timezone: timezoneSelect.value,
+      manager_role_id: managerRoleInput.value.trim() || null,
+      rules,
+    };
+
+    toggleLoading(form, true);
+    try {
+      const data = await state.request("/api/scrims.config.save", payload);
+      if (data.config) {
+        state.updateSnapshot("scrims", data.config);
+      }
+      showToast("スクリム設定を保存しました。", "success");
+      clear(root);
+      await renderScrims({ state, root, showToast });
+    } catch (error) {
+      showToast(error.message || "保存に失敗しました。", "error");
+    } finally {
+      toggleLoading(form, false);
+    }
+  });
+
+  section.append(form);
+
+  const runSection = createSection("手動実行");
+  const runForm = el("form");
+  const dryRunToggle = el("input", { type: "checkbox" });
+  dryRunToggle.checked = true;
+  const dryRunField = formField("Dry-run", dryRunToggle, "チェックしたままならリハーサルのみ実行します");
+  const resultArea = el("pre", { textContent: "" });
+  runForm.append(
+    dryRunField,
+    el("div", { className: "inline-actions" }, createButton("実行", { type: "submit" })),
+    resultArea,
+  );
+
+  runForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    toggleLoading(runForm, true);
+    try {
+      const data = await state.request("/api/scrims.run", { dry_run: dryRunToggle.checked });
+      resultArea.textContent = JSON.stringify(data.result, null, 2);
+      showToast("スクリム処理を実行しました。", "success");
+    } catch (error) {
+      showToast(error.message || "実行に失敗しました。", "error");
+    } finally {
+      toggleLoading(runForm, false);
+    }
+  });
+
+  runSection.append(runForm);
+
+  root.append(section, runSection);
+}

--- a/docs/assets/pages/settings.js
+++ b/docs/assets/pages/settings.js
@@ -1,0 +1,104 @@
+import {
+  clear,
+  createButton,
+  createSection,
+  el,
+  ensureSnapshot,
+  formField,
+  select,
+  textInput,
+  toggleLoading,
+} from "../ui.js";
+
+const defaultSettings = {
+  locale: "ja-JP",
+  timezone: "Asia/Tokyo",
+  member_index_mode: "exclude_bots",
+  member_count_strategy: "human_only",
+  api_base_url: "",
+  show_join_alerts: true,
+};
+
+export async function renderSettings({ state, root, showToast }) {
+  const snapshot = await ensureSnapshot(state, root).catch(() => null);
+  if (!snapshot) {
+    return;
+  }
+
+  const settings = { ...defaultSettings, ...(snapshot.settings || {}) };
+
+  const section = createSection("共通設定", "複数機能に跨る共通オプションを管理します。");
+  const form = el("form");
+  const localeSelect = select({
+    value: settings.locale,
+    options: [
+      { value: "ja-JP", label: "日本語" },
+      { value: "en-US", label: "English" },
+    ],
+  });
+  const timezoneSelect = select({
+    value: settings.timezone,
+    options: [
+      { value: "Asia/Tokyo", label: "JST" },
+      { value: "UTC", label: "UTC" },
+    ],
+  });
+  const memberIndexSelect = select({
+    value: settings.member_index_mode,
+    options: [
+      { value: "exclude_bots", label: "Botを除外" },
+      { value: "include_bots", label: "Botを含める" },
+    ],
+  });
+  const memberCountSelect = select({
+    value: settings.member_count_strategy,
+    options: [
+      { value: "human_only", label: "人間のみ" },
+      { value: "all_members", label: "全メンバー" },
+      { value: "boosters_priority", label: "ブースター優先" },
+    ],
+  });
+  const apiBaseInput = textInput({ value: settings.api_base_url || "", placeholder: "API Base URL (Pages向け表示)" });
+  const joinAlertsToggle = el("input", { type: "checkbox" });
+  joinAlertsToggle.checked = settings.show_join_alerts !== false;
+
+  form.append(
+    formField("言語", localeSelect),
+    formField("時刻帯", timezoneSelect),
+    formField("メンバー番号のカウント", memberIndexSelect),
+    formField("メンバー数の算出方法", memberCountSelect),
+    formField("Pages表示用API URL", apiBaseInput),
+    formField("Join通知を表示", joinAlertsToggle),
+    el("div", { className: "inline-actions" }, createButton("保存", { type: "submit" })),
+  );
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const payload = {
+      locale: localeSelect.value,
+      timezone: timezoneSelect.value,
+      member_index_mode: memberIndexSelect.value,
+      member_count_strategy: memberCountSelect.value,
+      api_base_url: apiBaseInput.value.trim() || null,
+      show_join_alerts: joinAlertsToggle.checked,
+    };
+
+    toggleLoading(form, true);
+    try {
+      const data = await state.request("/api/settings.save", payload);
+      if (data.settings) {
+        state.updateSnapshot("settings", data.settings);
+      }
+      showToast("共通設定を保存しました。", "success");
+      clear(root);
+      await renderSettings({ state, root, showToast });
+    } catch (error) {
+      showToast(error.message || "保存に失敗しました。", "error");
+    } finally {
+      toggleLoading(form, false);
+    }
+  });
+
+  section.append(form);
+  root.append(section);
+}

--- a/docs/assets/pages/verify.js
+++ b/docs/assets/pages/verify.js
@@ -1,0 +1,105 @@
+import {
+  clear,
+  createButton,
+  createSection,
+  el,
+  ensureSnapshot,
+  formField,
+  select,
+  textInput,
+  textarea,
+  toggleLoading,
+} from "../ui.js";
+
+const defaultVerify = {
+  channel_id: "",
+  role_id: "",
+  mode: "button",
+  prompt: "ボタンを押して認証を完了してください。",
+  message_id: "",
+};
+
+export async function renderVerify({ state, root, showToast }) {
+  const snapshot = await ensureSnapshot(state, root).catch(() => null);
+  if (!snapshot) {
+    return;
+  }
+
+  const config = { ...defaultVerify, ...(snapshot.verify || {}) };
+
+  const section = createSection("Verify メッセージ", "認証用のメッセージを設置します。");
+  const form = el("form");
+  const channelInput = textInput({ value: config.channel_id, placeholder: "チャンネルID", required: true });
+  const roleInput = textInput({ value: config.role_id, placeholder: "付与するロールID", required: true });
+  const modeSelect = select({
+    value: config.mode,
+    options: [
+      { value: "button", label: "ボタン" },
+      { value: "reaction", label: "リアクション" },
+    ],
+  });
+  const promptArea = textarea({ value: config.prompt || defaultVerify.prompt, rows: 4 });
+  const messageIdInput = textInput({ value: config.message_id || "", placeholder: "既存メッセージID (任意)" });
+
+  form.append(
+    formField("チャンネルID", channelInput),
+    formField("付与ロールID", roleInput),
+    formField("方式", modeSelect),
+    formField("案内文", promptArea),
+    formField("既存メッセージID", messageIdInput, "編集する場合のみ指定"),
+  );
+
+  const actions = el("div", { className: "inline-actions" });
+  const submitButton = createButton("保存", { type: "submit" });
+  const removeButton = createButton("削除", { variant: "danger" });
+  actions.append(submitButton, removeButton);
+  form.append(actions);
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const payload = {
+      channel_id: channelInput.value.trim(),
+      role_id: roleInput.value.trim(),
+      mode: modeSelect.value,
+      prompt: promptArea.value.trim() || defaultVerify.prompt,
+      message_id: messageIdInput.value.trim() || null,
+    };
+
+    toggleLoading(form, true);
+    try {
+      const data = await state.request("/api/verify.post", payload);
+      if (data.config) {
+        state.updateSnapshot("verify", data.config);
+      }
+      showToast("Verify 設定を保存しました。", "success");
+      clear(root);
+      await renderVerify({ state, root, showToast });
+    } catch (error) {
+      showToast(error.message || "保存に失敗しました。", "error");
+    } finally {
+      toggleLoading(form, false);
+    }
+  });
+
+  removeButton.addEventListener("click", async () => {
+    if (!state.snapshot?.verify) {
+      showToast("現在の設定はありません。", "info");
+      return;
+    }
+    toggleLoading(form, true);
+    try {
+      await state.request("/api/verify.remove", {});
+      state.updateSnapshot("verify", null);
+      showToast("Verify メッセージを削除しました。", "success");
+      clear(root);
+      await renderVerify({ state, root, showToast });
+    } catch (error) {
+      showToast(error.message || "削除に失敗しました。", "error");
+    } finally {
+      toggleLoading(form, false);
+    }
+  });
+
+  section.append(form);
+  root.append(section);
+}

--- a/docs/assets/pages/welcome.js
+++ b/docs/assets/pages/welcome.js
@@ -1,0 +1,173 @@
+import {
+  clear,
+  createButton,
+  createSection,
+  el,
+  ensureSnapshot,
+  formField,
+  select,
+  textInput,
+  textarea,
+  toggleLoading,
+} from "../ui.js";
+
+const defaultWelcome = {
+  channel_id: "",
+  title_template: "ようこそ、{username} さん！",
+  description_template: "あなたは **#{member_index}** 人目のメンバーです。",
+  member_index_mode: "exclude_bots",
+  join_field_label: "加入日時",
+  join_timezone: "Asia/Tokyo",
+  footer_text: "Nyaimlab",
+  thread_name_template: "",
+  buttons: [],
+};
+
+function createButtonRow(buttonsContainer, initial = {}) {
+  const row = el("div", { className: "button-row" });
+  const labelInput = textInput({ value: initial.label || "", placeholder: "ガイドを見る" });
+  labelInput.dataset.field = "label";
+  const targetSelect = select({
+    value: initial.target || "url",
+    options: [
+      { value: "url", label: "外部URL" },
+      { value: "channel", label: "Discordチャンネル" },
+    ],
+  });
+  targetSelect.dataset.field = "target";
+  const valueInput = textInput({
+    value: initial.value || "",
+    placeholder: initial.target === "channel" ? "123456789" : "https://",
+  });
+  valueInput.dataset.field = "value";
+  const emojiInput = textInput({ value: initial.emoji || "", placeholder: "🔔" });
+  emojiInput.dataset.field = "emoji";
+
+  targetSelect.addEventListener("change", () => {
+    valueInput.placeholder = targetSelect.value === "channel" ? "123456789" : "https://";
+  });
+
+  row.append(
+    formField("ラベル", labelInput),
+    formField("遷移タイプ", targetSelect),
+    formField("リンク/チャンネルID", valueInput),
+    formField("絵文字 (任意)", emojiInput),
+  );
+
+  const removeBtn = createButton("削除", { variant: "secondary" });
+  removeBtn.addEventListener("click", () => row.remove());
+  row.append(el("div", { className: "inline-actions" }, removeBtn));
+  buttonsContainer.append(row);
+}
+
+export async function renderWelcome({ state, root, showToast }) {
+  const snapshot = await ensureSnapshot(state, root).catch(() => null);
+  if (!snapshot) {
+    return;
+  }
+
+  const config = { ...defaultWelcome, ...(snapshot.welcome || {}) };
+
+  const section = createSection(
+    "Welcome Embed",
+    "入室時に投稿する埋め込みメッセージとボタンを設定します。",
+  );
+
+  const form = el("form");
+  const channelInput = textInput({ value: config.channel_id, placeholder: "チャンネルID", required: true });
+  const titleInput = textInput({ value: config.title_template });
+  const descriptionArea = textarea({ value: config.description_template, rows: 4 });
+  const memberIndexSelect = select({
+    value: config.member_index_mode,
+    options: [
+      { value: "exclude_bots", label: "Botを除外" },
+      { value: "include_bots", label: "Botを含める" },
+    ],
+  });
+  const joinLabelInput = textInput({ value: config.join_field_label });
+  const timezoneSelect = select({
+    value: config.join_timezone,
+    options: [
+      { value: "Asia/Tokyo", label: "JST (日本)" },
+      { value: "UTC", label: "UTC" },
+    ],
+  });
+  const footerInput = textInput({ value: config.footer_text });
+  const threadInput = textInput({ value: config.thread_name_template || "", placeholder: "歓迎スレッド {username}" });
+
+  form.append(
+    formField("投稿チャンネルID", channelInput),
+    formField("タイトルテンプレート", titleInput),
+    formField("本文テンプレート", descriptionArea, "Discord の書式と {username} などのプレースホルダーが利用できます"),
+    formField("メンバー番号のカウント方法", memberIndexSelect),
+    formField("加入日時ラベル", joinLabelInput),
+    formField("加入日時のタイムゾーン", timezoneSelect),
+    formField("フッター文字列", footerInput),
+    formField("スレッド名テンプレート (任意)", threadInput),
+  );
+
+  const buttonsSection = el("div", { className: "buttons-editor" });
+  buttonsSection.append(el("h3", { textContent: "ボタン設定" }));
+  const buttonsContainer = el("div", { className: "button-list" });
+  (config.buttons || []).forEach((btn) => createButtonRow(buttonsContainer, btn));
+  if (!buttonsContainer.childElementCount) {
+    createButtonRow(buttonsContainer);
+  }
+  const addButton = createButton("ボタンを追加", { variant: "secondary" });
+  addButton.addEventListener("click", () => createButtonRow(buttonsContainer));
+  buttonsSection.append(buttonsContainer, el("div", { className: "inline-actions" }, addButton));
+  form.append(buttonsSection);
+
+  const actions = el("div", { className: "inline-actions" });
+  const submitButton = createButton("保存する", { type: "submit" });
+  actions.append(submitButton);
+  form.append(actions);
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const payload = {
+      channel_id: channelInput.value.trim(),
+      title_template: titleInput.value.trim() || defaultWelcome.title_template,
+      description_template: descriptionArea.value.trim() || defaultWelcome.description_template,
+      member_index_mode: memberIndexSelect.value,
+      join_field_label: joinLabelInput.value.trim() || defaultWelcome.join_field_label,
+      join_timezone: timezoneSelect.value,
+      footer_text: footerInput.value.trim() || defaultWelcome.footer_text,
+      thread_name_template: threadInput.value.trim() || null,
+      buttons: [],
+    };
+
+    buttonsContainer.querySelectorAll(".button-row").forEach((row) => {
+      const label = row.querySelector('[data-field="label"]').value.trim();
+      const target = row.querySelector('[data-field="target"]').value;
+      const value = row.querySelector('[data-field="value"]').value.trim();
+      const emoji = row.querySelector('[data-field="emoji"]').value.trim();
+      if (!label || !value) {
+        return;
+      }
+      const entry = { label, target, value };
+      if (emoji) {
+        entry.emoji = emoji;
+      }
+      payload.buttons.push(entry);
+    });
+
+    toggleLoading(form, true);
+    try {
+      const data = await state.request("/api/welcome.post", payload);
+      if (data.config) {
+        state.updateSnapshot("welcome", data.config);
+      }
+      showToast("Welcome 設定を保存しました。", "success");
+      clear(root);
+      await renderWelcome({ state, root, showToast });
+    } catch (error) {
+      showToast(error.message || "保存に失敗しました。", "error");
+    } finally {
+      toggleLoading(form, false);
+    }
+  });
+
+  section.append(form);
+  root.append(section);
+}

--- a/docs/assets/state.js
+++ b/docs/assets/state.js
@@ -1,0 +1,145 @@
+const STORAGE_KEY = "nyaimcat.dashboard.connection.v1";
+
+export class DashboardState {
+  constructor() {
+    this.apiBaseUrl = "";
+    this.sessionToken = "";
+    this.guildId = "";
+    this.actorId = "";
+    this.clientId = "pages-dashboard";
+    this.snapshot = null;
+    this.loadingSnapshot = false;
+    this.load();
+  }
+
+  load() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) {
+        return;
+      }
+      const data = JSON.parse(raw);
+      this.apiBaseUrl = data.apiBaseUrl || "";
+      this.sessionToken = data.sessionToken || "";
+      this.guildId = data.guildId || "";
+      this.actorId = data.actorId || "";
+      this.clientId = data.clientId || "pages-dashboard";
+    } catch (error) {
+      console.warn("Failed to load dashboard settings", error);
+    }
+  }
+
+  save() {
+    const payload = {
+      apiBaseUrl: this.apiBaseUrl,
+      sessionToken: this.sessionToken,
+      guildId: this.guildId,
+      actorId: this.actorId,
+      clientId: this.clientId,
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  }
+
+  updateConnection(values) {
+    const { apiBaseUrl, sessionToken, guildId, actorId, clientId } = values;
+    if (apiBaseUrl !== undefined) {
+      this.apiBaseUrl = apiBaseUrl.trim();
+    }
+    if (sessionToken !== undefined) {
+      this.sessionToken = sessionToken.trim();
+    }
+    if (guildId !== undefined) {
+      this.guildId = guildId.trim();
+    }
+    if (actorId !== undefined) {
+      this.actorId = actorId.trim();
+    }
+    if (clientId !== undefined) {
+      this.clientId = clientId.trim() || "pages-dashboard";
+    }
+    this.save();
+  }
+
+  clearSnapshot() {
+    this.snapshot = null;
+  }
+
+  isReady() {
+    return Boolean(this.apiBaseUrl && this.sessionToken && this.guildId && this.actorId);
+  }
+
+  apiUrl(path) {
+    if (!path.startsWith("/")) {
+      path = `/${path}`;
+    }
+    return `${this.apiBaseUrl.replace(/\/$/, "")}${path}`;
+  }
+
+  async request(path, payload = undefined, { method = "POST" } = {}) {
+    if (!this.isReady()) {
+      throw new Error("API接続情報を先に保存してください。");
+    }
+
+    const url = this.apiUrl(path);
+    const headers = {
+      Authorization: `Bearer ${this.sessionToken}`,
+      "x-client": this.clientId || "pages-dashboard",
+      "x-guild-id": this.guildId,
+      "x-user-id": this.actorId,
+    };
+
+    const options = { method, headers };
+    if (payload !== undefined) {
+      options.headers["Content-Type"] = "application/json";
+      options.body = JSON.stringify(payload);
+    }
+
+    let response;
+    try {
+      response = await fetch(url, options);
+    } catch (error) {
+      throw new Error("ネットワークエラーが発生しました。");
+    }
+
+    let body = null;
+    try {
+      body = await response.json();
+    } catch (error) {
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      throw new Error("応答の解析に失敗しました。");
+    }
+
+    if (!response.ok || body.ok === false) {
+      throw new Error(body.error || `HTTP ${response.status}`);
+    }
+
+    return body.data || {};
+  }
+
+  async pullSnapshot() {
+    if (this.loadingSnapshot) {
+      return this.snapshot;
+    }
+    this.loadingSnapshot = true;
+    try {
+      const data = await this.request("/api/state.snapshot", {});
+      this.snapshot = data.state || {};
+      return this.snapshot;
+    } finally {
+      this.loadingSnapshot = false;
+    }
+  }
+
+  updateSnapshot(section, value) {
+    if (!this.snapshot) {
+      this.snapshot = {};
+    }
+    this.snapshot[section] = value;
+  }
+
+  setSnapshot(snapshot) {
+    this.snapshot = snapshot;
+  }
+}

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -1,0 +1,356 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f5f5f5;
+  --panel-bg: rgba(255, 255, 255, 0.85);
+  --border: rgba(0, 0, 0, 0.1);
+  --text: #1f2933;
+  --muted: #52606d;
+  --accent: #2563eb;
+  --accent-dark: #1e3a8a;
+  --danger: #dc2626;
+  --success: #047857;
+  --radius: 12px;
+  font-family: "Inter", "Noto Sans JP", system-ui, sans-serif;
+  line-height: 1.6;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(79, 70, 229, 0.08), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(16, 185, 129, 0.08), transparent 60%),
+    var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.site-header {
+  backdrop-filter: blur(12px);
+  background: rgba(255, 255, 255, 0.82);
+  border-bottom: 1px solid var(--border);
+  padding: 1.2rem clamp(1rem, 4vw, 2.5rem);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.site-header .brand h1 {
+  margin: 0;
+  font-size: clamp(1.3rem, 3vw, 1.8rem);
+}
+
+.site-header .brand p {
+  margin: 0.2rem 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.site-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.nav-link {
+  padding: 0.45rem 0.8rem;
+  border-radius: 999px;
+  text-decoration: none;
+  color: var(--muted);
+  border: 1px solid transparent;
+  transition: all 0.2s ease;
+  font-weight: 600;
+}
+
+.nav-link:hover {
+  color: var(--accent);
+  border-color: rgba(37, 99, 235, 0.4);
+  background: rgba(37, 99, 235, 0.08);
+}
+
+.nav-link.active {
+  color: white;
+  background: var(--accent);
+  border-color: transparent;
+  box-shadow: 0 8px 18px rgba(37, 99, 235, 0.15);
+}
+
+.app-root {
+  flex: 1;
+  width: min(1080px, 95vw);
+  margin: 2rem auto 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.8rem;
+}
+
+.panel {
+  background: var(--panel-bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: clamp(1.2rem, 2.5vw, 2rem);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.05);
+}
+
+.panel h2 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  font-size: clamp(1.1rem, 2.3vw, 1.6rem);
+}
+
+.panel-lead {
+  margin: 0 0 1.2rem;
+  color: var(--muted);
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-bottom: 1rem;
+}
+
+.form-label {
+  font-weight: 600;
+}
+
+.form-hint {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+input,
+select,
+textarea {
+  font: inherit;
+  padding: 0.55rem 0.7rem;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.9);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: rgba(37, 99, 235, 0.5);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+textarea {
+  resize: vertical;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn-primary {
+  color: white;
+  background: linear-gradient(135deg, var(--accent), #4f46e5);
+  box-shadow: 0 12px 24px rgba(79, 70, 229, 0.25);
+}
+
+.btn-secondary {
+  color: var(--accent);
+  background: rgba(37, 99, 235, 0.12);
+}
+
+.btn-danger {
+  color: white;
+  background: linear-gradient(135deg, var(--danger), #b91c1c);
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+}
+
+.btn:active {
+  transform: scale(0.98);
+}
+
+.button-row,
+.role-row,
+.attachment-row,
+.rule-row,
+.field-row {
+  display: grid;
+  gap: 0.6rem;
+  margin-bottom: 0.8rem;
+  padding: 0.8rem;
+  border: 1px dashed rgba(37, 99, 235, 0.3);
+  border-radius: 10px;
+  background: rgba(37, 99, 235, 0.04);
+}
+
+.button-row {
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  align-items: end;
+}
+
+.role-row {
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.attachment-row,
+.rule-row,
+.field-row {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.inline-actions {
+  display: flex;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.summary-card {
+  padding: 0.8rem 1rem;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.7);
+}
+
+.summary-card h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.summary-card p {
+  margin: 0.3rem 0 0;
+  font-weight: 700;
+  font-size: 1.2rem;
+}
+
+.toast-container {
+  position: fixed;
+  inset: auto 1rem 1rem auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  z-index: 20;
+}
+
+.toast {
+  padding: 0.6rem 1rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.8);
+  color: white;
+  transform: translateY(10px);
+  opacity: 0;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+  box-shadow: 0 14px 28px rgba(15, 23, 42, 0.25);
+}
+
+.toast-success {
+  background: rgba(4, 120, 87, 0.9);
+}
+
+.toast-error {
+  background: rgba(220, 38, 38, 0.92);
+}
+
+.toast.visible {
+  transform: translateY(0);
+  opacity: 1;
+}
+
+.site-footer {
+  padding: 1.2rem;
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.is-loading {
+  position: relative;
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.inline-status {
+  margin: 1rem 0;
+  color: var(--muted);
+}
+
+.inline-status.error {
+  color: var(--danger);
+}
+
+.spinner {
+  width: 1.1rem;
+  height: 1.1rem;
+  border-radius: 50%;
+  border: 2px solid rgba(37, 99, 235, 0.2);
+  border-top-color: rgba(37, 99, 235, 0.8);
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.table-scroll {
+  overflow: auto;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+}
+
+thead {
+  background: rgba(37, 99, 235, 0.08);
+}
+
+td,
+th {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+}
+
+pre {
+  background: rgba(15, 23, 42, 0.08);
+  padding: 0.8rem;
+  border-radius: 8px;
+  overflow: auto;
+}
+
+@media (max-width: 720px) {
+  .site-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .app-root {
+    width: min(100%, 94vw);
+  }
+}

--- a/docs/assets/ui.js
+++ b/docs/assets/ui.js
@@ -1,0 +1,160 @@
+const toastContainerId = "toast-container";
+
+export function el(tag, props = {}, ...children) {
+  const element = document.createElement(tag);
+  Object.entries(props).forEach(([key, value]) => {
+    if (value === null || value === undefined) {
+      return;
+    }
+    if (key === "className") {
+      element.className = value;
+    } else if (key === "textContent") {
+      element.textContent = value;
+    } else if (key === "innerHTML") {
+      element.innerHTML = value;
+    } else if (key.startsWith("on") && typeof value === "function") {
+      element.addEventListener(key.slice(2).toLowerCase(), value);
+    } else {
+      element.setAttribute(key, value);
+    }
+  });
+
+  children.flat().forEach((child) => {
+    if (child === null || child === undefined) {
+      return;
+    }
+    if (typeof child === "string") {
+      element.appendChild(document.createTextNode(child));
+    } else {
+      element.appendChild(child);
+    }
+  });
+  return element;
+}
+
+export function clear(node) {
+  while (node.firstChild) {
+    node.removeChild(node.firstChild);
+  }
+}
+
+export function showToast(message, type = "info") {
+  const container = document.getElementById(toastContainerId);
+  if (!container) {
+    console.warn("toast container is missing");
+    return;
+  }
+  const toast = el("div", { className: `toast toast-${type}` }, message);
+  container.appendChild(toast);
+  requestAnimationFrame(() => toast.classList.add("visible"));
+  setTimeout(() => {
+    toast.classList.remove("visible");
+    setTimeout(() => toast.remove(), 300);
+  }, 4000);
+}
+
+export function createSection(title, description = "") {
+  const section = el("section", { className: "panel" });
+  section.appendChild(el("h2", { textContent: title }));
+  if (description) {
+    section.appendChild(el("p", { className: "panel-lead", textContent: description }));
+  }
+  return section;
+}
+
+export function formField(label, control, description = "") {
+  const wrapper = el("label", { className: "form-field" });
+  wrapper.appendChild(el("span", { className: "form-label", textContent: label }));
+  wrapper.appendChild(control);
+  if (description) {
+    wrapper.appendChild(el("small", { className: "form-hint", textContent: description }));
+  }
+  return wrapper;
+}
+
+export function createButton(text, { type = "button", variant = "primary" } = {}) {
+  return el("button", { type, className: `btn btn-${variant}` }, text);
+}
+
+export function ensureSnapshot(state, root) {
+  if (state.snapshot) {
+    return Promise.resolve(state.snapshot);
+  }
+  const placeholder = el("div", { className: "inline-status" }, "設定を取得しています...");
+  root.appendChild(placeholder);
+  return state
+    .pullSnapshot()
+    .then((snapshot) => {
+      placeholder.remove();
+      showToast("サーバーから設定を読み込みました。", "success");
+      return snapshot;
+    })
+    .catch((error) => {
+      placeholder.textContent = error.message || "設定の取得に失敗しました。";
+      placeholder.classList.add("error");
+      throw error;
+    });
+}
+
+export function spinner() {
+  return el("span", { className: "spinner", "aria-hidden": "true" });
+}
+
+export function toggleLoading(element, loading) {
+  if (loading) {
+    element.classList.add("is-loading");
+  } else {
+    element.classList.remove("is-loading");
+  }
+}
+
+export function labeledSwitch(label, checked = false) {
+  const input = el("input", { type: "checkbox" });
+  input.checked = checked;
+  return formField(label, input);
+}
+
+export function textInput({
+  type = "text",
+  value = "",
+  placeholder = "",
+  name,
+  required = false,
+  pattern,
+}) {
+  const input = el("input", { type, value, placeholder });
+  if (name) {
+    input.name = name;
+  }
+  if (required) {
+    input.required = true;
+  }
+  if (pattern) {
+    input.pattern = pattern;
+  }
+  return input;
+}
+
+export function textarea({ value = "", rows = 6, name, placeholder = "" }) {
+  const area = el("textarea", { rows, placeholder });
+  area.value = value;
+  if (name) {
+    area.name = name;
+  }
+  return area;
+}
+
+export function select({ options = [], value, name }) {
+  const selectEl = el("select", {});
+  if (name) {
+    selectEl.name = name;
+  }
+  options.forEach((option) => {
+    const opt = el("option", { value: option.value, textContent: option.label });
+    if (value !== undefined && option.value === value) {
+      opt.selected = true;
+    }
+    selectEl.appendChild(opt);
+  });
+  return selectEl;
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Nyaimlab Bot Dashboard</title>
+    <link rel="stylesheet" href="./assets/styles.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="brand">
+        <h1>Nyaimlab Bot Dashboard</h1>
+        <p>GitHub Pages で運用する管理UI</p>
+      </div>
+      <nav id="nav" class="site-nav"></nav>
+    </header>
+    <main id="app" class="app-root"></main>
+    <div id="toast-container" class="toast-container"></div>
+    <footer class="site-footer">
+      <p>© Nyaimlab</p>
+    </footer>
+    <script type="module" src="./assets/app.js"></script>
+  </body>
+</html>

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ pandas>=2.2.0
 httpx>=0.27.0
 beautifulsoup4>=4.12.3
 python-dotenv>=1.0.1
+fastapi>=0.110.0
+uvicorn[standard]>=0.29.0
+pytest>=8.2.0

--- a/src/esclbot/bot.py
+++ b/src/esclbot/bot.py
@@ -1,235 +1,207 @@
-# src/esclbot/bot.py
+"""Discord bot entry point for ESCL scrim collection commands."""
 from __future__ import annotations
 
-import os
 import io
+import os
 import re
-from typing import Optional, List
+from typing import Optional
 
 import discord
 from discord import app_commands
 from discord.ext import commands
 from dotenv import load_dotenv
-import pandas as pd
 
-from .session import Session
-from .parser import parse_pasted_text
-from .scraper import (
-    extract_text_from_url,
-    guess_scrim_id,
-    find_game_urls_from_parent,
-)
+from .collector import CollectorError, CollectorResult, ScrimCollector
+from .session import SessionKey
 
-# =========================
-# Boot & Globals
-# =========================
 load_dotenv()
 
 INTENTS = discord.Intents.default()
-# スラッシュコマンドだけなら message_content は不要
 INTENTS.message_content = False
 
 BOT = commands.Bot(command_prefix="!", intents=INTENTS)
+COLLECTOR = ScrimCollector(default_scrim_group=os.getenv("DEFAULT_SCRIM_GROUP", ""))
 
-# セッションは (guild_id, channel_id, user_id) 毎に管理
-_sessions: dict[tuple[int, int, int], Session] = {}
 
-def _key_from_inter(inter: discord.Interaction) -> tuple[int, int, int]:
-    return (inter.guild_id or 0, inter.channel_id or 0, inter.user.id)
+def _session_key(inter: discord.Interaction) -> SessionKey:
+    return SessionKey(
+        guild_id=inter.guild_id or 0,
+        channel_id=inter.channel_id or 0,
+        user_id=inter.user.id,
+    )
 
-# =========================
-# Helper
-# =========================
-def _df_to_discord_file(df: pd.DataFrame, filename: str) -> discord.File:
-    buf = io.StringIO()
-    df.to_csv(buf, index=False)
-    data = io.BytesIO(buf.getvalue().encode("utf-8"))
-    return discord.File(data, filename=filename)
 
-# =========================
-# Classic flow: new → add → finish
-# =========================
+def _result_to_discord_file(result: CollectorResult) -> discord.File:
+    buffer = io.StringIO()
+    result.dataframe.to_csv(buffer, index=False)
+    payload = io.BytesIO(buffer.getvalue().encode("utf-8"))
+    return discord.File(payload, filename=result.filename)
+
+
+async def _reply_error(inter: discord.Interaction, exc: CollectorError) -> None:
+    message = str(exc)
+    if inter.response.is_done():
+        await inter.followup.send(message, ephemeral=True)
+    else:
+        await inter.response.send_message(message, ephemeral=True)
+
+
 @BOT.tree.command(name="escl_new", description="ESCL集計: 新しいセッションを開始")
 @app_commands.describe(scrim_group="G1〜G5（任意）", scrim_url="親ページのURL（任意）")
-async def escl_new(inter: discord.Interaction, scrim_group: Optional[str] = None, scrim_url: Optional[str] = None):
-    key = _key_from_inter(inter)
-    _sessions[key] = Session(scrim_group=scrim_group or os.getenv("DEFAULT_SCRIM_GROUP") or "", scrim_id=guess_scrim_id(scrim_url))
+async def escl_new(
+    inter: discord.Interaction,
+    scrim_group: Optional[str] = None,
+    scrim_url: Optional[str] = None,
+) -> None:
+    session = COLLECTOR.start_session(_session_key(inter), scrim_group=scrim_group, scrim_url=scrim_url)
     await inter.response.send_message(
-        f"新しいセッションを開始しました。group=`{_sessions[key].scrim_group or '未指定'}` scrim_id=`{_sessions[key].scrim_id or '不明'}`",
+        f"新しいセッションを開始しました。group=`{session.scrim_group or '未指定'}` "
+        f"scrim_id=`{session.scrim_id or '不明'}`",
         ephemeral=False,
     )
+
 
 @BOT.tree.command(name="escl_add", description="1試合分を追加（URL/テキスト/ファイルのどれか）")
-@app_commands.describe(url="ゲームページのURL", text="ESCLの『詳細な試合結果をコピー』で得たテキスト", file="txt/tsvファイル（任意）")
-async def escl_add(inter: discord.Interaction, url: Optional[str] = None, text: Optional[str] = None, file: Optional[discord.Attachment] = None):
-    key = _key_from_inter(inter)
-    if key not in _sessions:
-        await inter.response.send_message("まず /escl_new でセッションを開始してください。", ephemeral=True)
-        return
+@app_commands.describe(
+    url="ゲームページのURL",
+    text="ESCLの『詳細な試合結果をコピー』で得たテキスト",
+    file="txt/tsvファイル（任意）",
+)
+async def escl_add(
+    inter: discord.Interaction,
+    url: Optional[str] = None,
+    text: Optional[str] = None,
+    file: Optional[discord.Attachment] = None,
+) -> None:
+    key = _session_key(inter)
+
+    attachment_bytes: Optional[bytes] = None
+    if file is not None:
+        if file.size and file.size > 4 * 1024 * 1024:
+            await inter.response.send_message("ファイルが大きすぎます（4MBまで）。", ephemeral=True)
+            return
+        attachment_bytes = await file.read()
 
     await inter.response.defer(thinking=True, ephemeral=False)
-
-    payload: Optional[str] = None
-    src = "text"
-    if url:
-        payload = await extract_text_from_url(url)
-        src = "url"
-    elif text:
-        payload = text
-        src = "text"
-    elif file:
-        if file.size > 4 * 1024 * 1024:
-            await inter.followup.send("ファイルが大きすぎます（4MBまで）。")
-            return
-        content = await file.read()
-        payload = content.decode("utf-8", errors="ignore")
-        src = "file"
-
-    if not payload:
-        await inter.followup.send("入力が見つかりませんでした。`url` / `text` / `file` のいずれかを指定してください。")
-        return
-
     try:
-        df = parse_pasted_text(payload)
-    except Exception as e:
-        await inter.followup.send(f"テキスト解析に失敗しました: {e}")
+        record = await COLLECTOR.add_game(
+            key,
+            url=url,
+            text=text,
+            attachment_bytes=attachment_bytes,
+        )
+        session = COLLECTOR.summarise(key)
+    except CollectorError as exc:
+        await _reply_error(inter, exc)
         return
 
-    sess = _sessions[key]
-    game_no = len(sess.frames) + 1
-    df.insert(0, "game_no", game_no)
-    df.insert(0, "scrim_id", sess.scrim_id or (guess_scrim_id(url) if url else ""))
-    df.insert(0, "scrim_group", sess.scrim_group)
+    await inter.followup.send(
+        f"ゲーム{record.number}を取り込みました（入力: {record.source}）。現在 {session.total_games}/6"
+    )
 
-    sess.frames.append(df)
-    await inter.followup.send(f"ゲーム{game_no}を取り込みました（入力: {src}）。現在 {len(sess.frames)}/6")
 
 @BOT.tree.command(name="escl_list", description="セッションの取り込み状況を表示")
-async def escl_list(inter: discord.Interaction):
-    key = _key_from_inter(inter)
-    if key not in _sessions:
-        await inter.response.send_message("アクティブなセッションはありません。/escl_new から開始してください。", ephemeral=True)
+async def escl_list(inter: discord.Interaction) -> None:
+    key = _session_key(inter)
+    try:
+        session = COLLECTOR.summarise(key)
+    except CollectorError as exc:
+        await _reply_error(inter, exc)
         return
-    sess = _sessions[key]
+
     await inter.response.send_message(
-        f"取り込み済み: {len(sess.frames)} 件 / 6  （group={sess.scrim_group or '未指定'}, scrim_id={sess.scrim_id or '不明'}）",
+        "取り込み済み: {count} 件 / 6  （group={group}, scrim_id={scrim_id})".format(
+            count=session.total_games,
+            group=session.scrim_group or "未指定",
+            scrim_id=session.scrim_id or "不明",
+        ),
         ephemeral=False,
     )
 
+
 @BOT.tree.command(name="escl_clear", description="セッションを破棄してやり直し")
-async def escl_clear(inter: discord.Interaction):
-    key = _key_from_inter(inter)
-    _sessions.pop(key, None)
+async def escl_clear(inter: discord.Interaction) -> None:
+    COLLECTOR.clear_session(_session_key(inter))
     await inter.response.send_message("セッションをクリアしました。/escl_new から再開してください。", ephemeral=False)
 
+
 @BOT.tree.command(name="escl_finish", description="6試合（未満でも可）をまとめてCSVで出力")
-async def escl_finish(inter: discord.Interaction):
-    key = _key_from_inter(inter)
-    if key not in _sessions or not _sessions[key].frames:
-        await inter.response.send_message("取り込み済みデータがありません。/escl_add でデータを追加してください。", ephemeral=True)
+async def escl_finish(inter: discord.Interaction) -> None:
+    key = _session_key(inter)
+    await inter.response.defer(thinking=True, ephemeral=False)
+    try:
+        result = COLLECTOR.finish_session(key)
+    except CollectorError as exc:
+        await _reply_error(inter, exc)
         return
 
-    await inter.response.defer(thinking=True, ephemeral=False)
-    sess = _sessions.pop(key)
-    df_all = pd.concat(sess.frames, ignore_index=True)
-    df_all = df_all.rename(columns={"scrim_group": "group", "game_no": "game"})
-    
-    fname = f"ESCL_{(sess.scrim_group or 'G?')}_{(sess.scrim_id or 'unknown')}.csv"
-    await inter.followup.send(content="CSVを生成しました。", file=_df_to_discord_file(df_all, fname))
+    await inter.followup.send(content="CSVを生成しました。", file=_result_to_discord_file(result))
 
-# =========================
-# URLだけで完結するコマンド（新規）
-# =========================
-@BOT.tree.command(name="escl_from_parent", description="親ページURLから自動でG1〜G6を収集してCSVを返す（貼付不要）")
+
+@BOT.tree.command(
+    name="escl_from_parent",
+    description="親ページURLから自動でG1〜G6を収集してCSVを返す（貼付不要）",
+)
 @app_commands.describe(parent_url="その日のスクリム親ページURL", scrim_group="G1〜G5（任意）")
-async def escl_from_parent(inter: discord.Interaction, parent_url: str, scrim_group: Optional[str] = None):
-        await inter.response.defer(thinking=True, ephemeral=False)
-
-    from .scraper import collect_game_texts_from_group
-    pairs = collect_game_texts_from_group(parent_url, max_games=6)
-
-    if not pairs:
-        await inter.followup.send("親ページから GAME 1〜6 の詳細テキストを取得できませんでした。URLをご確認ください。")
-        return
-
-    rows = []
-    sid = guess_scrim_id(parent_url)
-    for game_no, txt in pairs:
-        try:
-            df = parse_pasted_text(txt)
-        except Exception as e:
-            await inter.followup.send(f"GAME {game_no} の解析に失敗しました: {e}")
-            return
-        df.insert(0, "game_no", game_no)
-        df.insert(0, "scrim_id", sid or "")
-        df.insert(0, "scrim_group", scrim_group or "")
-        rows.append(df)
-
-    df_all = pd.concat(rows, ignore_index=True)
-    df_all = df_all.rename(columns={"scrim_group": "group", "game_no": "game"})
-    fname = f"ESCL_{(scrim_group or 'G?')}_{(sid or 'unknown')}.csv"
-    await inter.followup.send(content="CSVを生成しました。", file=_df_to_discord_file(df_all, fname))
-
-@BOT.tree.command(name="escl_from_urls", description="ゲームURLを1〜6個まとめて渡してCSVを返す（改行/空白区切り）")
-@app_commands.describe(urls="ゲームURLを空白または改行で区切って1〜6個（G1〜G6）", scrim_group="G1〜G5（任意）")
-async def escl_from_urls(inter: discord.Interaction, urls: str, scrim_group: Optional[str] = None):
+async def escl_from_parent(
+    inter: discord.Interaction,
+    parent_url: str,
+    scrim_group: Optional[str] = None,
+) -> None:
     await inter.response.defer(thinking=True, ephemeral=False)
-
-    candidates = [u.strip() for u in re.split(r"[\s,]+", urls) if u.strip()]
-    candidates = candidates[:6]
-    if not candidates:
-        await inter.followup.send("URLが見つかりませんでした。")
+    try:
+        result = await COLLECTOR.collect_from_parent(parent_url, scrim_group=scrim_group)
+    except CollectorError as exc:
+        await _reply_error(inter, exc)
         return
 
-    rows: List[pd.DataFrame] = []
-    sid = guess_scrim_id(candidates[0])
-    for i, url in enumerate(candidates, start=1):
-        if not re.match(r"^https?://", url):
-            await inter.followup.send(f"URL形式エラー: {url}")
-            return
-        txt = await extract_text_from_url(url)
-        if not txt:
-            await inter.followup.send(f"ゲーム{i}の抽出に失敗：{url}\n（ページの『詳細な試合結果をコピー』テキストでの貼付なら確実です）")
-            return
-        df = parse_pasted_text(txt)
-        df.insert(0, "game_no", i)
-        df.insert(0, "scrim_id", sid or "")
-        df.insert(0, "scrim_group", scrim_group or "")
-        rows.append(df)
+    await inter.followup.send(content="CSVを生成しました。", file=_result_to_discord_file(result))
 
-    df_all = pd.concat(rows, ignore_index=True)
 
-    df_all = df_all.rename(columns={"scrim_group": "group", "game_no": "game"})
+@BOT.tree.command(
+    name="escl_from_urls",
+    description="ゲームURLを1〜6個まとめて渡してCSVを返す（改行/空白区切り）",
+)
+@app_commands.describe(urls="ゲームURLを空白または改行で区切って1〜6個（G1〜G6）", scrim_group="G1〜G5（任意）")
+async def escl_from_urls(
+    inter: discord.Interaction,
+    urls: str,
+    scrim_group: Optional[str] = None,
+) -> None:
+    await inter.response.defer(thinking=True, ephemeral=False)
+    candidates = [u.strip() for u in re.split(r"[\s,]+", urls) if u.strip()]
+    try:
+        result = await COLLECTOR.collect_from_urls(candidates, scrim_group=scrim_group)
+    except CollectorError as exc:
+        await _reply_error(inter, exc)
+        return
 
-    fname = f"ESCL_{(scrim_group or 'G?')}_{(sid or 'unknown')}.csv"
-    await inter.followup.send(content="CSVを生成しました。", file=_df_to_discord_file(df_all, fname))
+    await inter.followup.send(content="CSVを生成しました。", file=_result_to_discord_file(result))
 
-# =========================
-# Sync & Run
-# =========================
+
 @BOT.event
-async def on_ready():
-    gid = os.getenv("GUILD_ID")
-    if gid and gid.isdigit():
-        guild = discord.Object(id=int(gid))
-        # ★ 追加: グローバル定義をギルドへコピー
+async def on_ready() -> None:
+    guild_id = os.getenv("GUILD_ID")
+    if guild_id and guild_id.isdigit():
+        guild = discord.Object(id=int(guild_id))
         BOT.tree.copy_global_to(guild=guild)
-        # ★ そのギルドに対して同期
         synced = await BOT.tree.sync(guild=guild)
-        print(f"Slash commands synced to guild {gid}. count={len(synced)}")
+        print(f"Slash commands synced to guild {guild_id}. count={len(synced)}")
     else:
         synced = await BOT.tree.sync()
         print(f"Slash commands synced globally. count={len(synced)}")
 
-    # デバッグ: 読み込まれているコマンド名を表示
-    print("Loaded commands:", [c.name for c in BOT.tree.get_commands()])
-    print(f"Logged in as {BOT.user} (ID: {BOT.user.id})")
+    print("Loaded commands:", [command.name for command in BOT.tree.get_commands()])
+    if BOT.user:
+        print(f"Logged in as {BOT.user} (ID: {BOT.user.id})")
 
-def main():
+
+def main() -> None:
     token = os.getenv("DISCORD_TOKEN")
     if not token:
         raise SystemExit("DISCORD_TOKEN が設定されていません（.env を確認）")
     BOT.run(token)
+
 
 if __name__ == "__main__":
     main()

--- a/src/esclbot/collector.py
+++ b/src/esclbot/collector.py
@@ -1,0 +1,167 @@
+"""High-level orchestration for ESCL scrim collection commands."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Sequence
+
+import pandas as pd
+
+from .parser import parse_pasted_text
+from .scraper import (
+    collect_game_texts_from_group,
+    extract_text_from_url,
+    guess_scrim_id,
+)
+from .session import (
+    GameRecord,
+    ScrimSession,
+    SessionKey,
+    SessionManager,
+    SessionNotFoundError,
+)
+
+
+class CollectorError(RuntimeError):
+    """Raised when an operator-facing validation error occurs."""
+
+
+@dataclass
+class CollectorResult:
+    """Result of a bulk export operation."""
+
+    filename: str
+    dataframe: pd.DataFrame
+
+
+class ScrimCollector:
+    """Coordinate scrim sessions and export helpers for the Discord bot."""
+
+    def __init__(self, default_scrim_group: str = "") -> None:
+        self._sessions = SessionManager(default_scrim_group)
+
+    def start_session(
+        self,
+        key: SessionKey,
+        *,
+        scrim_group: Optional[str] = None,
+        scrim_url: Optional[str] = None,
+    ) -> ScrimSession:
+        """Initialise a session for the supplied guild/channel/user key."""
+
+        scrim_id = guess_scrim_id(scrim_url)
+        return self._sessions.start_session(key, scrim_group, scrim_id)
+
+    async def add_game(
+        self,
+        key: SessionKey,
+        *,
+        url: Optional[str] = None,
+        text: Optional[str] = None,
+        attachment_bytes: Optional[bytes] = None,
+    ) -> GameRecord:
+        """Parse incoming data and add a game to the active session."""
+
+        try:
+            session = self._sessions.require_session(key)
+        except SessionNotFoundError as exc:  # pragma: no cover - defensive
+            raise CollectorError("まず /escl_new でセッションを開始してください。") from exc
+
+        payload: Optional[str] = None
+        source = "text"
+        if url:
+            payload = await extract_text_from_url(url)
+            source = "url"
+        elif text:
+            payload = text
+        elif attachment_bytes is not None:
+            payload = attachment_bytes.decode("utf-8", errors="ignore")
+            source = "file"
+
+        if not payload:
+            raise CollectorError("入力が見つかりませんでした。`url` / `text` / `file` のいずれかを指定してください。")
+
+        frame = parse_pasted_text(payload)
+        scrim_id_hint = guess_scrim_id(url) if url else None
+        return session.add_frame(frame, source=source, scrim_id=scrim_id_hint)
+
+    def summarise(self, key: SessionKey) -> ScrimSession:
+        """Return session state for progress reporting."""
+
+        try:
+            return self._sessions.require_session(key)
+        except SessionNotFoundError as exc:  # pragma: no cover - defensive
+            raise CollectorError("アクティブなセッションはありません。/escl_new から開始してください。") from exc
+
+    def clear_session(self, key: SessionKey) -> None:
+        """Remove the session for the supplied key."""
+
+        self._sessions.clear_session(key)
+
+    def finish_session(self, key: SessionKey) -> CollectorResult:
+        """Export the collected games and clear the active session."""
+
+        session = self._sessions.get_session(key)
+        if session is None or session.total_games == 0:
+            raise CollectorError("取り込み済みデータがありません。/escl_add でデータを追加してください。")
+
+        dataframe = session.combined_frame()
+        filename = session.build_filename()
+        self._sessions.clear_session(key)
+        return CollectorResult(filename=filename, dataframe=dataframe)
+
+    async def collect_from_urls(
+        self, urls: Sequence[str], *, scrim_group: Optional[str] = None
+    ) -> CollectorResult:
+        """Fetch multiple game URLs and generate a combined dataframe."""
+
+        cleaned = [u.strip() for u in urls if u and u.strip()]
+        if not cleaned:
+            raise CollectorError("URLが見つかりませんでした。")
+
+        session = ScrimSession(
+            scrim_group=scrim_group or self._sessions.default_group,
+            scrim_id=guess_scrim_id(cleaned[0]),
+        )
+
+        for idx, url in enumerate(cleaned, start=1):
+            if not url.startswith("http"):
+                raise CollectorError(f"URL形式エラー: {url}")
+            payload = await extract_text_from_url(url)
+            if not payload:
+                raise CollectorError(
+                    f"ゲーム{idx}の抽出に失敗：{url}\n（ページの『詳細な試合結果をコピー』テキストでの貼付なら確実です）"
+                )
+            frame = parse_pasted_text(payload)
+            session.add_frame(frame, source="url", scrim_id=guess_scrim_id(url), game_number=idx)
+
+        dataframe = session.combined_frame()
+        filename = session.build_filename()
+        return CollectorResult(filename=filename, dataframe=dataframe)
+
+    async def collect_from_parent(
+        self, parent_url: str, *, scrim_group: Optional[str] = None, max_games: int = 6
+    ) -> CollectorResult:
+        """Collect GAME1〜6 texts from a parent scrim URL."""
+
+        pairs = await collect_game_texts_from_group(parent_url, max_games=max_games)
+        if not pairs:
+            raise CollectorError("親ページから GAME 1〜6 の詳細テキストを取得できませんでした。URLをご確認ください。")
+
+        session = ScrimSession(
+            scrim_group=scrim_group or self._sessions.default_group,
+            scrim_id=guess_scrim_id(parent_url),
+        )
+        for number, payload in pairs:
+            frame = parse_pasted_text(payload)
+            session.add_frame(frame, source="url", scrim_id=session.scrim_id, game_number=number)
+
+        dataframe = session.combined_frame()
+        filename = session.build_filename()
+        return CollectorResult(filename=filename, dataframe=dataframe)
+
+
+__all__ = [
+    "CollectorError",
+    "CollectorResult",
+    "ScrimCollector",
+]

--- a/src/esclbot/scraper.py
+++ b/src/esclbot/scraper.py
@@ -1,319 +1,147 @@
-# src/esclbot/scraper.py
+"""Helpers for retrieving ESCL scrim payloads from the web."""
 from __future__ import annotations
-import asyncio
+
 import re
-from typing import List, Optional
-from urllib.parse import urljoin
+from typing import List, Optional, Tuple
 
 import httpx
 from bs4 import BeautifulSoup
 
-# ========== 既存の静的フェッチ（フォールバック用） ==========
-def fetch_html(url: str, timeout_sec: int = 15) -> Optional[str]:
-    try:
-        with httpx.Client(follow_redirects=True, timeout=timeout_sec, headers={
-            "User-Agent": "Mozilla/5.0 (ESCL Collector Bot)"
-        }) as client:
-            r = client.get(url)
-            r.raise_for_status()
-            return r.text
-    except Exception:
-        return None
-
-# 「詳細」テキストの必須ヘッダ（判定用）
+USER_AGENT = "Mozilla/5.0 (Nyaimcat Scrim Collector)"
 REQUIRED_HEADERS = {
-    "team_name","team_num","player_name","character","placement",
-    "kills","assists","damage","shots","hits","accuracy",
-    "headshots","headshots_accuracy","survival_time"
+    "team_name",
+    "team_num",
+    "player_name",
+    "character",
+    "placement",
+    "kills",
+    "assists",
+    "damage",
+    "shots",
+    "hits",
+    "accuracy",
+    "headshots",
+    "headshots_accuracy",
+    "survival_time",
 }
+SCRIM_PATH_RE = re.compile(r"(/scrims/[0-9a-f\-]{8,}/[0-9a-f\-]{8,})", re.IGNORECASE)
+
 
 def _looks_like_detailed_payload(text: str) -> bool:
     if not text:
         return False
     head = text.splitlines()[0].strip().lower()
-    cols = re.split(r"\t|\s{2,}", head)
-    cols = {c.strip() for c in cols if c.strip()}
-    return REQUIRED_HEADERS.issubset(cols)
+    columns = re.split(r"\t|\s{2,}", head)
+    columns = {c.strip() for c in columns if c.strip()}
+    return REQUIRED_HEADERS.issubset(columns)
 
-# ===========================================================
-# Playwright (Chromium) でレンダリングして抽出
-# ===========================================================
-async def _extract_with_playwright(url: str) -> Optional[str]:
-    from playwright.async_api import async_playwright
-    async with async_playwright() as p:
-        browser = await p.chromium.launch(headless=True)
-        ctx = await browser.new_context(user_agent="Mozilla/5.0 (ESCL Collector Bot)")
-        page = await ctx.new_page()
-        await page.goto(url, wait_until="domcontentloaded", timeout=30000)
 
-        # ボタン待ち
-        btn = page.locator("text=詳細な試合結果をコピー").first
-        try:
-            await btn.wait_for(state="visible", timeout=30000)
-        except Exception:
-            html = await page.content()
-            await browser.close()
-            # フォールバック：静的抽出
-            soup = BeautifulSoup(html, "html.parser")
-            for el in soup.find_all(attrs={"data-clipboard-text": True}):
-                txt = (el.get("data-clipboard-text") or "").strip()
-                if _looks_like_detailed_payload(txt):
-                    return txt
-            return None
-
-        # data-clipboard-text 取得
-        handle = await btn.element_handle()
-        txt = None
-        if handle:
-            attr = await handle.get_attribute("data-clipboard-text")
-            if attr and _looks_like_detailed_payload(attr.strip()):
-                txt = attr.strip()
-            if not txt:
-                parent = await handle.evaluate_handle("el => el.closest('[data-clipboard-text]')")
-                if parent:
-                    attr = await parent.get_attribute("data-clipboard-text")
-                    if attr and _looks_like_detailed_payload(attr.strip()):
-                        txt = attr.strip()
-
-        if not txt:
-            html = await page.content()
-            soup = BeautifulSoup(html, "html.parser")
-            for tag in soup.find_all(["pre","code","textarea"]):
-                payload = tag.get_text("\n").strip()
-                if _looks_like_detailed_payload(payload):
-                    txt = payload
-                    break
-            if not txt:
-                for sc in soup.find_all("script"):
-                    raw = sc.get_text(" ").strip()
-                    if "team_name" in raw:
-                        payload = raw.replace("\\n","\n").replace("\\t","\t")
-                        m = re.search(r"(team_name[^\r\n]+(?:[\r\n].+)*)", payload)
-                        if m and _looks_like_detailed_payload(m.group(1).strip()):
-                            txt = m.group(1).strip()
-                            break
-
-        await browser.close()
-        return txt
-
-async def extract_text_from_url(url: str, timeout_sec: int = 15) -> Optional[str]:
-    """非同期：まずPlaywright、だめなら静的HTML解析で詳細テキストを取る"""
+async def _fetch_html(url: str, *, timeout: int = 15) -> Optional[str]:
+    headers = {"User-Agent": USER_AGENT}
     try:
-        txt = await _extract_with_playwright(url)
-        if txt:
-            return txt
-    except Exception:
-        pass
-
-    # フォールバック：ブロッキングI/Oを別スレッドで
-    html = await asyncio.to_thread(fetch_html, url, timeout_sec)
-    if not html:
+        async with httpx.AsyncClient(follow_redirects=True, timeout=timeout, headers=headers) as client:
+            response = await client.get(url)
+            response.raise_for_status()
+            return response.text
+    except httpx.HTTPError:
         return None
-    soup = BeautifulSoup(html, "html.parser")
-    for el in soup.find_all(attrs={"data-clipboard-text": True}):
-        txt = (el.get("data-clipboard-text") or "").strip()
-        if _looks_like_detailed_payload(txt):
-            return txt
+
+
+def _extract_clipboard_payload(soup: BeautifulSoup) -> Optional[str]:
+    for element in soup.find_all(attrs={"data-clipboard-text": True}):
+        payload = (element.get("data-clipboard-text") or "").strip()
+        if payload and _looks_like_detailed_payload(payload):
+            return payload
     return None
 
-SCRIM_PATH_RE = re.compile(r"(/scrims/[0-9a-f\-]{8,}/[0-9a-f\-]{8,})")
+
+def _extract_payload_from_html(html: str) -> Optional[str]:
+    soup = BeautifulSoup(html, "html.parser")
+    payload = _extract_clipboard_payload(soup)
+    if payload:
+        return payload
+
+    # Fallback: search for pre/code/textarea blocks that resemble the dataset.
+    for tag in soup.find_all(["pre", "code", "textarea"]):
+        candidate = tag.get_text("\n").strip()
+        if candidate and _looks_like_detailed_payload(candidate):
+            return candidate
+
+    for script in soup.find_all("script"):
+        raw = (script.get_text(" ") or "").strip()
+        if "team_name" not in raw:
+            continue
+        decoded = raw.replace("\\n", "\n").replace("\\t", "\t")
+        match = re.search(r"(team_name[^\r\n]+(?:[\r\n].+)*)", decoded)
+        if match:
+            candidate = match.group(1).strip()
+            if candidate and _looks_like_detailed_payload(candidate):
+                return candidate
+    return None
+
+
+async def extract_text_from_url(url: str, timeout: int = 15) -> Optional[str]:
+    """Retrieve the detailed match result text from a game page."""
+
+    html = await _fetch_html(url, timeout=timeout)
+    if not html:
+        return None
+    return _extract_payload_from_html(html)
+
 
 def guess_scrim_id(url: Optional[str]) -> Optional[str]:
     if not url:
         return None
-    m = re.search(r"/scrims/([0-9a-f\-]{8,})", url)
-    return m.group(1) if m else None
+    match = re.search(r"/scrims/([0-9a-f\-]{8,})", url)
+    return match.group(1) if match else None
+
 
 def _extract_game_urls_from_html(html: str, base_url: str, limit: int) -> List[str]:
     from urllib.parse import urljoin
-    sid_hint = guess_scrim_id(base_url)
-    urls, seen = [], set()
-    for m in SCRIM_PATH_RE.finditer(html or ""):
-        full = urljoin(base_url, m.group(1))
-        sid = guess_scrim_id(full)
-        if sid_hint and sid != sid_hint:
-            continue
-        if full not in seen:
-            seen.add(full)
-            urls.append(full)
-        if len(urls) >= limit:
-            break
-    return urls
 
-async def _find_urls_with_playwright(parent_url: str, limit: int = 6) -> List[str]:
-    from playwright.async_api import async_playwright
-    async with async_playwright() as p:
-        browser = await p.chromium.launch(headless=True)
-        ctx = await browser.new_context(user_agent="Mozilla/5.0 (ESCL Collector Bot)")
-        page = await ctx.new_page()
-        await page.goto(parent_url, wait_until="domcontentloaded", timeout=30000)
-        html = await page.content()
-        await browser.close()
-    return _extract_game_urls_from_html(html, parent_url, limit)
-
-async def find_game_urls_from_parent(parent_url: str, limit: int = 6) -> List[str]:
-    """非同期：親URLから /scrims/<sid>/<gid> を最大6件抽出"""
-    try:
-        urls = await _find_urls_with_playwright(parent_url, limit)
-        if urls:
-            return urls
-    except Exception:
-        pass
-    html = await asyncio.to_thread(fetch_html, parent_url)
-    if not html:
-        return []
-    return _extract_game_urls_from_html(html, parent_url, limit)
-
-def extract_text_from_url(url: str, timeout_sec: int = 15) -> Optional[str]:
-    """
-    ゲームページURLから『詳細な試合結果』のテキストを取得。
-    1) Playwright でレンダリングして data-clipboard-text を読む
-    2) 失敗したら静的HTMLからフォールバック抽出
-    """
-    try:
-        return asyncio.run(_extract_with_playwright(url))
-    except Exception:
-        pass  # フォールバックへ
-
-    # フォールバック（静的HTML）
-    html = fetch_html(url, timeout_sec=timeout_sec)
-    if not html:
-        return None
-    soup = BeautifulSoup(html, "html.parser")
-    # data-clipboard-text 総当り
-    for el in soup.find_all(attrs={"data-clipboard-text": True}):
-        txt = el.get("data-clipboard-text", "").strip()
-        if _looks_like_detailed_payload(txt):
-            return txt
-    return None
-
-# ===========================================================
-# 親URL → GAME1〜6のURLを抽出（レンダリング後のDOMから拾う）
-# ===========================================================
-async def _find_urls_with_playwright(parent_url: str, limit: int = 6) -> List[str]:
-    from playwright.async_api import async_playwright
-
-    async with async_playwright() as p:
-        browser = await p.chromium.launch(headless=True)
-        ctx = await browser.new_context(user_agent="Mozilla/5.0 (ESCL Collector Bot)")
-        page = await ctx.new_page()
-        await page.goto(parent_url, wait_until="domcontentloaded", timeout=30000)
-
-        # DOM全体の content を取り、正規表現で /scrims/<sid>/<gid> を抽出
-        html = await page.content()
-        await browser.close()
-
-    return _extract_game_urls_from_html(html, parent_url, limit)
-
-SCRIM_PATH_RE = re.compile(r"(/scrims/[0-9a-f\-]{8,}/[0-9a-f\-]{8,})")
-
-def _extract_game_urls_from_html(html: str, base_url: str, limit: int) -> List[str]:
-    from urllib.parse import urljoin
-    # 親URLの scrimId を優先
     sid_hint = guess_scrim_id(base_url)
     urls: List[str] = []
     seen = set()
 
-    for m in SCRIM_PATH_RE.finditer(html):
-        path = m.group(1)
-        full = urljoin(base_url, path)
-        # sid一致のものだけ
-        sid = guess_scrim_id(full)
+    for match in SCRIM_PATH_RE.finditer(html or ""):
+        path = match.group(1)
+        absolute = urljoin(base_url, path)
+        sid = guess_scrim_id(absolute)
         if sid_hint and sid != sid_hint:
             continue
-        if full not in seen:
-            seen.add(full)
-            urls.append(full)
+        if absolute in seen:
+            continue
+        seen.add(absolute)
+        urls.append(absolute)
         if len(urls) >= limit:
             break
     return urls
 
-def guess_scrim_id(url: Optional[str]) -> Optional[str]:
-    if not url:
-        return None
-    m = re.search(r"/scrims/([0-9a-f\-]{8,})", url)
-    return m.group(1) if m else None
 
-def find_game_urls_from_parent(parent_url: str, limit: int = 6) -> List[str]:
-    try:
-        return asyncio.run(_find_urls_with_playwright(parent_url, limit))
-    except Exception:
-        # フォールバック（静的HTML）
-        html = fetch_html(parent_url)
-        if not html:
-            return []
-        return _extract_game_urls_from_html(html, parent_url, limit)
-
-import re
-import asyncio
-from bs4 import BeautifulSoup
-
-async def _collect_game_texts_with_playwright(group_url: str, max_games: int = 6):
-    from playwright.async_api import async_playwright
-
-    async with async_playwright() as p:
-        browser = await p.chromium.launch(headless=True)
-        ctx = await browser.new_context(user_agent="Mozilla/5.0 (ESCL Collector Bot)")
-        page = await ctx.new_page()
-        await page.goto(group_url, wait_until="domcontentloaded", timeout=30000)
-        await page.wait_for_load_state("networkidle")
-        await page.wait_for_timeout(600)
-
-        results = []  # (game_no, text)
-
-        for i in range(1, max_games + 1):
-            clicked = False
-            candidates = [
-                page.get_by_role("tab", name=re.compile(rf"^GAME\s*{i}\b", re.I)),
-                page.get_by_text(re.compile(rf"^GAME\s*{i}\b", re.I)),
-                page.locator(f"text=GAME {i}"),
-                page.locator(f"text=GAME{i}"),
-            ]
-            for loc in candidates:
-                try:
-                    await loc.first.click(timeout=2000)
-                    clicked = True
-                    break
-                except:
-                    pass
-
-            payload = None
-            try:
-                btn = page.locator("text=詳細な試合結果をコピー").first
-                await btn.wait_for(state="visible", timeout=8000)
-
-                handle = await btn.element_handle()
-                if handle:
-                    attr = await handle.get_attribute("data-clipboard-text")
-                    if attr and attr.strip():
-                        payload = attr.strip()
-
-                    if not payload:
-                        parent = await handle.evaluate_handle("el => el.closest('[data-clipboard-text]')")
-                        if parent:
-                            attr = await parent.get_attribute("data-clipboard-text")
-                            if attr and attr.strip():
-                                payload = attr.strip()
-
-                if not payload:
-                    html = await page.content()
-                    soup = BeautifulSoup(html, "html.parser")
-                    for el in soup.find_all(attrs={"data-clipboard-text": True}):
-                        cand = (el.get("data-clipboard-text") or "").strip()
-                        if cand:
-                            payload = cand
-                            break
-            except:
-                pass
-
-            if payload:
-                results.append((i, payload))
-
-        await browser.close()
-        return results
-
-def collect_game_texts_from_group(group_url: str, max_games: int = 6):
-    try:
-        return asyncio.run(_collect_game_texts_with_playwright(group_url, max_games))
-    except:
+async def find_game_urls_from_parent(parent_url: str, limit: int = 6) -> List[str]:
+    html = await _fetch_html(parent_url)
+    if not html:
         return []
+    return _extract_game_urls_from_html(html, parent_url, limit)
+
+
+async def collect_game_texts_from_group(
+    parent_url: str, *, max_games: int = 6
+) -> List[Tuple[int, str]]:
+    """Return ``(game_no, payload)`` pairs collected from the parent page."""
+
+    urls = await find_game_urls_from_parent(parent_url, limit=max_games)
+    results: List[Tuple[int, str]] = []
+    for index, url in enumerate(urls, start=1):
+        payload = await extract_text_from_url(url)
+        if payload:
+            results.append((index, payload))
+    return results
+
+
+__all__ = [
+    "collect_game_texts_from_group",
+    "extract_text_from_url",
+    "find_game_urls_from_parent",
+    "guess_scrim_id",
+]

--- a/src/esclbot/session.py
+++ b/src/esclbot/session.py
@@ -1,18 +1,138 @@
+"""Session management primitives for ESCL scrim collection."""
 from __future__ import annotations
+
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import Dict, List, Optional
+
 import pandas as pd
 
-@dataclass
-class Session:
-    scrim_group: Optional[str] = None
-    scrim_id: Optional[str] = None
-    games: List[pd.DataFrame] = field(default_factory=list)
 
-    def add_game(self, df: pd.DataFrame) -> int:
-        self.games.append(df)
-        return len(self.games)
+@dataclass(frozen=True)
+class SessionKey:
+    """Unique identifier for a scrim collection session."""
+
+    guild_id: int
+    channel_id: int
+    user_id: int
+
+
+@dataclass
+class GameRecord:
+    """Single game dataframe captured during a session."""
+
+    number: int
+    source: str
+    frame: pd.DataFrame
+
+
+@dataclass
+class ScrimSession:
+    """In-memory container for games collected from a guild/channel/user."""
+
+    scrim_group: str = ""
+    scrim_id: Optional[str] = None
+    records: List[GameRecord] = field(default_factory=list)
+
+    def add_frame(
+        self,
+        frame: pd.DataFrame,
+        *,
+        source: str,
+        scrim_id: Optional[str] = None,
+        game_number: Optional[int] = None,
+    ) -> GameRecord:
+        """Store a parsed dataframe and return the associated record."""
+
+        if scrim_id and not self.scrim_id:
+            self.scrim_id = scrim_id
+
+        number = game_number if game_number is not None else len(self.records) + 1
+        decorated = frame.copy()
+        decorated.insert(0, "game_no", number)
+        decorated.insert(0, "scrim_id", self.scrim_id or "")
+        decorated.insert(0, "scrim_group", self.scrim_group)
+
+        record = GameRecord(number=number, source=source, frame=decorated)
+        self.records.append(record)
+        return record
 
     @property
-    def count(self) -> int:
-        return len(self.games)
+    def total_games(self) -> int:
+        """Return the number of collected games."""
+
+        return len(self.records)
+
+    def combined_frame(self) -> pd.DataFrame:
+        """Return a dataframe merging all stored games."""
+
+        if not self.records:
+            raise ValueError("No games have been collected.")
+        merged = pd.concat([record.frame for record in self.records], ignore_index=True)
+        return merged.rename(columns={"scrim_group": "group", "game_no": "game"})
+
+    def build_filename(self) -> str:
+        """Generate a descriptive CSV filename for the session."""
+
+        group = self.scrim_group or "G?"
+        scrim_id = self.scrim_id or "unknown"
+        return f"ESCL_{group}_{scrim_id}.csv"
+
+
+class SessionError(RuntimeError):
+    """Base error for session management issues."""
+
+
+class SessionNotFoundError(SessionError):
+    """Raised when attempting to access a missing session."""
+
+
+class SessionManager:
+    """Manage scrim sessions keyed by guild/channel/user."""
+
+    def __init__(self, default_group: str = "") -> None:
+        self._sessions: Dict[SessionKey, ScrimSession] = {}
+        self._default_group = default_group
+
+    def start_session(
+        self,
+        key: SessionKey,
+        scrim_group: Optional[str] = None,
+        scrim_id: Optional[str] = None,
+    ) -> ScrimSession:
+        """Create or overwrite a session for the supplied key."""
+
+        session = ScrimSession(
+            scrim_group=scrim_group or self._default_group,
+            scrim_id=scrim_id,
+        )
+        self._sessions[key] = session
+        return session
+
+    def get_session(self, key: SessionKey) -> Optional[ScrimSession]:
+        """Return a session if present."""
+
+        return self._sessions.get(key)
+
+    def require_session(self, key: SessionKey) -> ScrimSession:
+        """Return a session, raising if none exists."""
+
+        session = self.get_session(key)
+        if session is None:
+            raise SessionNotFoundError("Session not initialised for this channel/user.")
+        return session
+
+    def clear_session(self, key: SessionKey) -> None:
+        """Remove a stored session if present."""
+
+        self._sessions.pop(key, None)
+
+    def clear_all(self) -> None:
+        """Remove all active sessions (mainly for testing)."""
+
+        self._sessions.clear()
+
+    @property
+    def default_group(self) -> str:
+        """Expose the configured default scrim group."""
+
+        return self._default_group

--- a/src/nyaimlab/__init__.py
+++ b/src/nyaimlab/__init__.py
@@ -1,0 +1,6 @@
+"""Nyaimlab admin API package."""
+from __future__ import annotations
+
+from .app import app, create_app
+
+__all__ = ["app", "create_app"]

--- a/src/nyaimlab/__main__.py
+++ b/src/nyaimlab/__main__.py
@@ -1,0 +1,16 @@
+"""Entry point for running the Nyaimlab admin API."""
+from __future__ import annotations
+
+import os
+
+import uvicorn
+
+
+def main() -> None:
+    host = os.getenv("API_HOST", "0.0.0.0")
+    port = int(os.getenv("API_PORT", "8080"))
+    uvicorn.run("nyaimlab.app:app", host=host, port=port, reload=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nyaimlab/app.py
+++ b/src/nyaimlab/app.py
@@ -1,0 +1,223 @@
+"""FastAPI application exposing the Nyaimlab management API."""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request, status
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
+from .auth import require_context
+from .context import RequestContext
+from .schemas import (
+    APIResponse,
+    AuditExportRequest,
+    AuditSearchRequest,
+    GuidelineTemplate,
+    GuidelineTestRequest,
+    IntroduceConfig,
+    IntroduceSchema,
+    RoleEmojiMapRequest,
+    RoleRemovalRequest,
+    RolesConfig,
+    RolesPreviewRequest,
+    ScrimConfig,
+    ScrimRunRequest,
+    SettingsPayload,
+    VerifyConfig,
+    WelcomeConfig,
+)
+from .store import STORE
+
+
+def _success(audit_entry, data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {"ok": True, "audit_id": audit_entry.audit_id, "data": data}
+    return payload
+
+
+def _failure(status_code: int, message: str, audit_entry=None) -> JSONResponse:
+    body: Dict[str, Any] = {"ok": False, "error": message}
+    if audit_entry is not None:
+        body["audit_id"] = audit_entry.audit_id
+    return JSONResponse(status_code=status_code, content=body)
+
+
+router = APIRouter(prefix="/api")
+
+
+@router.post("/state.snapshot", response_model=APIResponse)
+def state_snapshot(ctx: RequestContext = Depends(require_context)) -> Dict[str, Any]:
+    snapshot, audit_entry = STORE.snapshot(ctx)
+    return _success(audit_entry, {"state": snapshot})
+
+
+@router.post("/welcome.post", response_model=APIResponse)
+def welcome_post(
+    payload: WelcomeConfig, ctx: RequestContext = Depends(require_context)
+) -> Dict[str, Any]:
+    config, audit_entry = STORE.save_welcome(ctx, payload)
+    return _success(audit_entry, {"config": config})
+
+
+@router.post("/guideline.save", response_model=APIResponse)
+def guideline_save(
+    payload: GuidelineTemplate, ctx: RequestContext = Depends(require_context)
+) -> Dict[str, Any]:
+    template, audit_entry = STORE.save_guideline(ctx, payload)
+    return _success(audit_entry, {"template": template})
+
+
+@router.post("/guideline.test", response_model=APIResponse)
+def guideline_test(
+    payload: GuidelineTestRequest, ctx: RequestContext = Depends(require_context)
+) -> Dict[str, Any]:
+    preview, audit_entry = STORE.test_guideline(ctx, payload)
+    return _success(audit_entry, {"preview": preview})
+
+
+@router.post("/verify.post", response_model=APIResponse)
+def verify_post(
+    payload: VerifyConfig, ctx: RequestContext = Depends(require_context)
+) -> Dict[str, Any]:
+    config, audit_entry = STORE.save_verify(ctx, payload)
+    return _success(audit_entry, {"config": config})
+
+
+@router.post("/verify.remove", response_model=APIResponse)
+def verify_remove(ctx: RequestContext = Depends(require_context)) -> Dict[str, Any]:
+    audit_entry = STORE.remove_verify(ctx)
+    return _success(audit_entry)
+
+
+@router.post("/roles.post", response_model=APIResponse)
+def roles_post(
+    payload: RolesConfig, ctx: RequestContext = Depends(require_context)
+) -> Dict[str, Any]:
+    config, audit_entry = STORE.save_roles(ctx, payload)
+    return _success(audit_entry, {"config": config})
+
+
+@router.post("/roles.mapEmoji", response_model=APIResponse)
+def roles_map_emoji(
+    payload: RoleEmojiMapRequest, ctx: RequestContext = Depends(require_context)
+) -> Dict[str, Any]:
+    mapping, audit_entry = STORE.map_role_emoji(ctx, payload)
+    return _success(audit_entry, {"mapping": mapping})
+
+
+@router.post("/roles.remove", response_model=APIResponse)
+def roles_remove(
+    payload: RoleRemovalRequest, ctx: RequestContext = Depends(require_context)
+) -> Dict[str, Any]:
+    config, audit_entry = STORE.remove_role(ctx, payload)
+    return _success(audit_entry, {"config": config})
+
+
+@router.post("/roles.preview", response_model=APIResponse)
+def roles_preview(
+    payload: RolesPreviewRequest, ctx: RequestContext = Depends(require_context)
+) -> Dict[str, Any]:
+    preview, audit_entry = STORE.preview_roles(ctx, payload)
+    return _success(audit_entry, {"preview": preview})
+
+
+@router.post("/introduce.post", response_model=APIResponse)
+def introduce_post(
+    payload: IntroduceConfig, ctx: RequestContext = Depends(require_context)
+) -> Dict[str, Any]:
+    config, audit_entry = STORE.save_introduce(ctx, payload)
+    return _success(audit_entry, {"config": config})
+
+
+@router.post("/introduce.schema.save", response_model=APIResponse)
+def introduce_schema_save(
+    payload: IntroduceSchema, ctx: RequestContext = Depends(require_context)
+) -> JSONResponse | Dict[str, Any]:
+    try:
+        schema, audit_entry = STORE.save_introduce_schema(ctx, payload)
+    except ValueError as exc:  # duplicate field IDs, etc.
+        audit_entry = STORE.log_failure(
+            ctx,
+            "introduce.schema.save",
+            str(exc),
+            payload=payload.model_dump(mode="python"),
+        )
+        return _failure(status.HTTP_400_BAD_REQUEST, str(exc), audit_entry)
+    return _success(audit_entry, {"schema": schema})
+
+
+@router.post("/scrims.config.save", response_model=APIResponse)
+def scrims_config_save(
+    payload: ScrimConfig, ctx: RequestContext = Depends(require_context)
+) -> Dict[str, Any]:
+    config, audit_entry = STORE.save_scrim_config(ctx, payload)
+    return _success(audit_entry, {"config": config})
+
+
+@router.post("/scrims.run", response_model=APIResponse)
+def scrims_run(
+    payload: ScrimRunRequest, ctx: RequestContext = Depends(require_context)
+) -> JSONResponse | Dict[str, Any]:
+    try:
+        result, audit_entry = STORE.run_scrim(ctx, payload)
+    except ValueError as exc:
+        audit_entry = STORE.log_failure(
+            ctx,
+            "scrims.run",
+            str(exc),
+            payload={"dry_run": payload.dry_run},
+        )
+        return _failure(status.HTTP_400_BAD_REQUEST, str(exc), audit_entry)
+    return _success(audit_entry, {"result": result})
+
+
+@router.post("/settings.save", response_model=APIResponse)
+def settings_save(
+    payload: SettingsPayload, ctx: RequestContext = Depends(require_context)
+) -> Dict[str, Any]:
+    settings, audit_entry = STORE.save_settings(ctx, payload)
+    return _success(audit_entry, {"settings": settings})
+
+
+@router.post("/audit.search", response_model=APIResponse)
+def audit_search(
+    payload: AuditSearchRequest, ctx: RequestContext = Depends(require_context)
+) -> Dict[str, Any]:
+    results, audit_entry = STORE.search_audit(ctx, payload)
+    return _success(audit_entry, {"results": results})
+
+
+@router.post("/audit.export", response_model=APIResponse)
+def audit_export(
+    payload: AuditExportRequest, ctx: RequestContext = Depends(require_context)
+) -> Dict[str, Any]:
+    content, audit_entry = STORE.export_audit(ctx, payload)
+    data = {"format": payload.format.value, "content": content}
+    return _success(audit_entry, data)
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="Nyaimlab Management API", version="0.1.0")
+
+    @app.exception_handler(RequestValidationError)
+    async def validation_exception_handler(  # type: ignore[override]
+        request: Request, exc: RequestValidationError
+    ) -> JSONResponse:
+        message = "Validation error"
+        return _failure(status.HTTP_422_UNPROCESSABLE_ENTITY, f"{message}: {exc}")
+
+    @app.exception_handler(HTTPException)
+    async def http_exception_handler(  # type: ignore[override]
+        request: Request, exc: HTTPException
+    ) -> JSONResponse:
+        return _failure(exc.status_code, str(exc.detail))
+
+    @app.get("/healthz")
+    async def healthcheck() -> Dict[str, Any]:
+        return {"ok": True}
+
+    app.include_router(router)
+    return app
+
+
+app = create_app()

--- a/src/nyaimlab/auth.py
+++ b/src/nyaimlab/auth.py
@@ -1,0 +1,59 @@
+"""Authentication helpers for the management API."""
+from __future__ import annotations
+
+import os
+from typing import Tuple
+
+from fastapi import Header, HTTPException, status
+
+from .context import RequestContext
+
+
+def _extract_bearer_token(authorization: str) -> str:
+    if not authorization:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing Authorization header")
+    prefix = "Bearer "
+    if not authorization.startswith(prefix):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid Authorization scheme")
+    token = authorization[len(prefix) :].strip()
+    if not token:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Empty bearer token")
+    return token
+
+
+def _normalize_scopes(raw_scopes: str | None) -> Tuple[str, ...]:
+    if not raw_scopes:
+        return ()
+    items = []
+    for piece in raw_scopes.split(","):
+        item = piece.strip()
+        if item:
+            items.append(item)
+    return tuple(items)
+
+
+def require_context(
+    authorization: str = Header(..., alias="Authorization"),
+    x_client: str = Header(..., alias="x-client"),
+    x_guild_id: str = Header(..., alias="x-guild-id"),
+    x_user_id: str | None = Header(None, alias="x-user-id"),
+    x_scopes: str | None = Header(None, alias="x-scopes"),
+) -> RequestContext:
+    """Validate headers and produce a :class:`RequestContext`."""
+
+    token = _extract_bearer_token(authorization)
+    expected = os.getenv("API_AUTH_TOKEN")
+    if expected and token != expected:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid session token")
+
+    actor = x_user_id or "unknown"
+    if not x_guild_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing x-guild-id header")
+
+    return RequestContext(
+        guild_id=x_guild_id,
+        client_id=x_client,
+        session_id=token,
+        actor_id=actor,
+        scopes=_normalize_scopes(x_scopes),
+    )

--- a/src/nyaimlab/context.py
+++ b/src/nyaimlab/context.py
@@ -1,0 +1,26 @@
+"""Request context utilities for the admin API."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+
+@dataclass(frozen=True)
+class RequestContext:
+    """Metadata extracted from authenticated requests."""
+
+    guild_id: str
+    client_id: str
+    session_id: str
+    actor_id: str
+    scopes: Tuple[str, ...] = ()
+
+    def to_metadata(self) -> dict[str, str]:
+        """Return a serialisable metadata representation for audit logging."""
+
+        return {
+            "guild_id": self.guild_id,
+            "client_id": self.client_id,
+            "session_id": self.session_id,
+            "actor_id": self.actor_id,
+        }

--- a/src/nyaimlab/schemas.py
+++ b/src/nyaimlab/schemas.py
@@ -1,0 +1,344 @@
+"""Pydantic models for the Nyaimlab admin API."""
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import List, Optional
+
+from pydantic import (
+    AnyHttpUrl,
+    BaseModel,
+    ConfigDict,
+    Field,
+    FieldValidationInfo,
+    PositiveInt,
+    field_validator,
+)
+
+
+class MemberIndexMode(str, Enum):
+    """How to count members when calculating the welcome index."""
+
+    INCLUDE_BOTS = "include_bots"
+    EXCLUDE_BOTS = "exclude_bots"
+
+
+class Locale(str, Enum):
+    """Available locales for the dashboard and Discord output."""
+
+    JA_JP = "ja-JP"
+    EN_US = "en-US"
+
+
+class Timezone(str, Enum):
+    """Timezone options supported by the runtime."""
+
+    UTC = "UTC"
+    JST = "Asia/Tokyo"
+
+
+class WelcomeButtonTarget(str, Enum):
+    """Types of supported welcome buttons."""
+
+    URL = "url"
+    CHANNEL = "channel"
+
+
+class WelcomeButton(BaseModel):
+    """Button definition for the welcome embed."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    label: str = Field(..., min_length=1, max_length=80)
+    target: WelcomeButtonTarget
+    value: str = Field(..., min_length=1, max_length=256)
+    emoji: Optional[str] = Field(
+        default=None,
+        description="Optional custom emoji identifier (unicode or emoji ID).",
+    )
+
+
+class WelcomeConfig(BaseModel):
+    """Configuration payload for the welcome embed flow."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    channel_id: str = Field(..., min_length=1)
+    title_template: str = Field(
+        default="ようこそ、{username} さん！",
+        description="Title template supporting Discord format placeholders.",
+    )
+    description_template: str = Field(
+        default="あなたは **#{member_index}** 人目のメンバーです。",
+        description="Description template shown within the embed.",
+    )
+    member_index_mode: MemberIndexMode = MemberIndexMode.EXCLUDE_BOTS
+    join_field_label: str = Field(default="加入日時", max_length=32)
+    join_timezone: Timezone = Timezone.JST
+    buttons: List[WelcomeButton] = Field(default_factory=list)
+    footer_text: str = Field(default="Nyaimlab", max_length=64)
+    thread_name_template: Optional[str] = Field(
+        default=None,
+        description="Optional thread name template if follow-up threads are created.",
+    )
+
+
+class GuidelineTemplate(BaseModel):
+    """Stored DM guideline template."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    content: str = Field(
+        ..., min_length=1, description="Markdown or plain text sent via DM."
+    )
+    attachments: List[AnyHttpUrl] = Field(
+        default_factory=list,
+        description="Optional list of hosted asset URLs attached to the DM.",
+    )
+
+
+class GuidelineTestRequest(BaseModel):
+    """Request payload for testing the guideline DM."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    target_user_id: Optional[str] = Field(
+        default=None,
+        description="Optional Discord user ID to send a preview DM (simulated).",
+    )
+    dry_run: bool = Field(
+        default=True, description="If true, no persistent state is modified."
+    )
+
+
+class VerifyMode(str, Enum):
+    BUTTON = "button"
+    REACTION = "reaction"
+
+
+class VerifyConfig(BaseModel):
+    """Verification message configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    channel_id: str = Field(..., min_length=1)
+    role_id: str = Field(..., min_length=1)
+    mode: VerifyMode = VerifyMode.BUTTON
+    prompt: str = Field(
+        default="ボタンを押して認証を完了してください。",
+        max_length=2000,
+    )
+    message_id: Optional[str] = Field(
+        default=None,
+        description="Existing Discord message ID to update in-place if present.",
+    )
+
+
+class RoleStyle(str, Enum):
+    BUTTONS = "buttons"
+    SELECT = "select"
+    REACTIONS = "reactions"
+
+
+class RoleEntry(BaseModel):
+    """Definition for a self-assignable role."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    role_id: str = Field(..., min_length=1)
+    label: str = Field(..., min_length=1, max_length=80)
+    description: Optional[str] = Field(
+        default=None,
+        max_length=200,
+        description="Optional helper text shown on the dashboard.",
+    )
+    emoji: Optional[str] = Field(default=None, max_length=64)
+    hidden: bool = False
+    sort_order: int = Field(default=0)
+
+
+class RolesConfig(BaseModel):
+    """Configuration payload for the role distribution message."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    channel_id: str = Field(..., min_length=1)
+    style: RoleStyle
+    roles: List[RoleEntry] = Field(default_factory=list)
+    message_content: Optional[str] = Field(
+        default=None,
+        description="Optional plain-text message that accompanies the controls.",
+    )
+
+
+class RoleEmojiMapRequest(BaseModel):
+    """Payload for mapping or removing reaction emojis."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    role_id: str
+    emoji: Optional[str] = Field(
+        default=None,
+        description="Emoji to associate. None removes the mapping.",
+    )
+
+
+class RoleRemovalRequest(BaseModel):
+    """Request to remove a role configuration entry."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    role_id: Optional[str] = Field(
+        default=None,
+        description="If omitted the entire role panel is removed.",
+    )
+
+
+class RolesPreviewRequest(BaseModel):
+    """Request payload for generating a preview of the role UI."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    locale: Locale = Locale.JA_JP
+
+
+class IntroduceField(BaseModel):
+    """Definition of a modal field for the /introduce command."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    field_id: str = Field(..., min_length=1, max_length=32)
+    label: str = Field(..., min_length=1, max_length=45)
+    placeholder: Optional[str] = Field(default=None, max_length=100)
+    required: bool = Field(default=True)
+    enabled: bool = Field(default=True)
+    max_length: PositiveInt = Field(default=300, le=1024)
+
+
+class IntroduceSchema(BaseModel):
+    """Collection of fields that make up the introduction modal."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    fields: List[IntroduceField] = Field(default_factory=list)
+
+
+class IntroduceConfig(BaseModel):
+    """Configuration for posting introductions."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    channel_id: str
+    mention_role_ids: List[str] = Field(default_factory=list)
+    embed_title: str = Field(
+        default="自己紹介",
+        max_length=256,
+    )
+    footer_text: Optional[str] = Field(default=None, max_length=64)
+
+
+class ScrimDay(str, Enum):
+    SUN = "sun"
+    MON = "mon"
+    TUE = "tue"
+    WED = "wed"
+    THU = "thu"
+    FRI = "fri"
+    SAT = "sat"
+
+
+class ScrimRule(BaseModel):
+    """Configuration for weekly scrim surveys."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    day: ScrimDay = ScrimDay.SUN
+    survey_open_hour: int = Field(default=12, ge=0, le=23)
+    survey_close_hour: int = Field(default=22, ge=0, le=23)
+    notify_channel_id: str
+    min_team_members: PositiveInt = Field(default=3, le=10)
+
+    @field_validator("survey_close_hour")
+    @classmethod
+    def validate_close(cls, v: int, info: FieldValidationInfo):  # pragma: no cover - simple guard
+        data = info.data
+        if "survey_open_hour" in data and v == data["survey_open_hour"]:
+            raise ValueError("survey_close_hour must differ from survey_open_hour")
+        return v
+
+
+class ScrimConfig(BaseModel):
+    """Top-level scrim automation configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    timezone: Timezone = Timezone.JST
+    rules: List[ScrimRule] = Field(default_factory=list)
+    manager_role_id: Optional[str] = None
+
+
+class ScrimRunRequest(BaseModel):
+    """Manual trigger for the scrim helper."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    dry_run: bool = Field(default=True)
+
+
+class AuditSearchRequest(BaseModel):
+    """Search parameters for audit events."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    since: Optional[datetime] = None
+    until: Optional[datetime] = None
+    action: Optional[str] = Field(default=None, max_length=64)
+    user_id: Optional[str] = Field(default=None)
+    channel_id: Optional[str] = Field(default=None)
+    limit: PositiveInt = Field(default=100, le=500)
+
+
+class AuditExportFormat(str, Enum):
+    NDJSON = "ndjson"
+    CSV = "csv"
+
+
+class AuditExportRequest(AuditSearchRequest):
+    """Export request, extending the search parameters with a format."""
+
+    format: AuditExportFormat = AuditExportFormat.NDJSON
+
+
+class MemberCountStrategy(str, Enum):
+    ALL_MEMBERS = "all_members"
+    HUMAN_ONLY = "human_only"
+    BOOSTERS_PRIORITY = "boosters_priority"
+
+
+class SettingsPayload(BaseModel):
+    """Guild-level bot configuration that affects multiple features."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    locale: Locale = Locale.JA_JP
+    timezone: Timezone = Timezone.JST
+    member_index_mode: MemberIndexMode = MemberIndexMode.EXCLUDE_BOTS
+    member_count_strategy: MemberCountStrategy = MemberCountStrategy.HUMAN_ONLY
+    api_base_url: Optional[AnyHttpUrl] = Field(default=None)
+    show_join_alerts: bool = Field(default=True)
+
+
+class APIResponse(BaseModel):
+    """Consistent envelope for successful responses."""
+
+    ok: bool = True
+    audit_id: Optional[str] = None
+    data: Optional[dict] = None
+
+
+class ErrorResponse(BaseModel):
+    """Consistent envelope for errors."""
+
+    ok: bool = False
+    error: str
+    audit_id: Optional[str] = None

--- a/src/nyaimlab/store.py
+++ b/src/nyaimlab/store.py
@@ -1,0 +1,525 @@
+"""In-memory data store for the Nyaimlab management API."""
+from __future__ import annotations
+
+import csv
+import io
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from threading import Lock
+from typing import Any, Dict, List, Optional
+from uuid import uuid4
+
+from pydantic import BaseModel
+
+from .context import RequestContext
+from .schemas import (
+    AuditExportFormat,
+    AuditExportRequest,
+    AuditSearchRequest,
+    GuidelineTemplate,
+    GuidelineTestRequest,
+    IntroduceConfig,
+    IntroduceSchema,
+    RoleEmojiMapRequest,
+    RoleRemovalRequest,
+    RolesConfig,
+    RolesPreviewRequest,
+    ScrimConfig,
+    ScrimRunRequest,
+    SettingsPayload,
+    VerifyConfig,
+    WelcomeConfig,
+)
+
+
+def _dump_model(model: Optional[BaseModel]) -> Optional[Dict[str, Any]]:
+    """Convert a pydantic model into a plain dictionary."""
+
+    if model is None:
+        return None
+    return model.model_dump(mode="python")
+
+
+def _clone(data: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Deep copy a JSON-serialisable dictionary."""
+
+    if data is None:
+        return None
+    return json.loads(json.dumps(data))
+
+
+@dataclass
+class AuditEntry:
+    """Single audit log entry."""
+
+    audit_id: str
+    timestamp: datetime
+    guild_id: str
+    action: str
+    ok: bool
+    actor_id: str
+    client_id: str
+    session_id: str
+    payload: Optional[Dict[str, Any]] = None
+    error: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self, include_payload: bool = False) -> Dict[str, Any]:
+        data: Dict[str, Any] = {
+            "audit_id": self.audit_id,
+            "timestamp": self.timestamp.isoformat(),
+            "guild_id": self.guild_id,
+            "action": self.action,
+            "ok": self.ok,
+            "actor_id": self.actor_id,
+            "client_id": self.client_id,
+            "session_id": self.session_id,
+        }
+        if self.error:
+            data["error"] = self.error
+        if self.metadata:
+            data.update(self.metadata)
+        if include_payload and self.payload is not None:
+            data["payload"] = self.payload
+        return data
+
+
+@dataclass
+class GuildState:
+    """Stored state for a guild."""
+
+    welcome: Optional[Dict[str, Any]] = None
+    guideline: Optional[Dict[str, Any]] = None
+    verify: Optional[Dict[str, Any]] = None
+    roles: Optional[Dict[str, Any]] = None
+    role_emoji_map: Dict[str, str] = field(default_factory=dict)
+    introduce: Optional[Dict[str, Any]] = None
+    introduce_schema: Dict[str, Any] = field(default_factory=lambda: {"fields": []})
+    scrims: Optional[Dict[str, Any]] = None
+    settings: Dict[str, Any] = field(default_factory=dict)
+
+
+class Store:
+    """Thread-safe state container with audit logging."""
+
+    def __init__(self) -> None:
+        self._guilds: Dict[str, GuildState] = {}
+        self._audit: List[AuditEntry] = []
+        self._lock = Lock()
+
+    # ------------------------------------------------------------------
+    # Helper utilities
+    # ------------------------------------------------------------------
+    def _ensure_state(self, guild_id: str) -> GuildState:
+        state = self._guilds.get(guild_id)
+        if state is None:
+            state = GuildState()
+            self._guilds[guild_id] = state
+        return state
+
+    def _record_audit(
+        self,
+        ctx: RequestContext,
+        action: str,
+        *,
+        ok: bool,
+        payload: Optional[Dict[str, Any]] = None,
+        error: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> AuditEntry:
+        entry = AuditEntry(
+            audit_id=str(uuid4()),
+            timestamp=datetime.now(timezone.utc),
+            guild_id=ctx.guild_id,
+            action=action,
+            ok=ok,
+            actor_id=ctx.actor_id,
+            client_id=ctx.client_id,
+            session_id=ctx.session_id,
+            payload=payload,
+            error=error,
+            metadata=metadata or {},
+        )
+        with self._lock:
+            self._audit.append(entry)
+        return entry
+
+    def snapshot(
+        self, ctx: RequestContext, *, audit_limit: int = 50
+    ) -> tuple[Dict[str, Any], AuditEntry]:
+        """Return the stored configuration for a guild."""
+
+        with self._lock:
+            state = self._ensure_state(ctx.guild_id)
+            payload: Dict[str, Any] = {
+                "welcome": _clone(state.welcome),
+                "guideline": _clone(state.guideline),
+                "verify": _clone(state.verify),
+                "roles": _clone(state.roles),
+                "role_emoji_map": dict(state.role_emoji_map),
+                "introduce": _clone(state.introduce),
+                "introduce_schema": _clone(state.introduce_schema),
+                "scrims": _clone(state.scrims),
+                "settings": _clone(state.settings),
+            }
+            recent: List[Dict[str, Any]] = []
+            if audit_limit > 0:
+                recent = [
+                    entry.to_dict(include_payload=True)
+                    for entry in self._audit
+                    if entry.guild_id == ctx.guild_id
+                ][-audit_limit:]
+                payload["audit_recent"] = recent
+
+        serialised = json.loads(json.dumps(payload))
+        entry = self._record_audit(
+            ctx,
+            "state.snapshot",
+            ok=True,
+            metadata={"audit_sample": len(recent)},
+        )
+        return serialised, entry
+
+    # ------------------------------------------------------------------
+    # Welcome
+    # ------------------------------------------------------------------
+    def save_welcome(
+        self, ctx: RequestContext, payload: WelcomeConfig
+    ) -> tuple[Dict[str, Any], AuditEntry]:
+        data = _dump_model(payload) or {}
+        with self._lock:
+            state = self._ensure_state(ctx.guild_id)
+            state.welcome = data
+        entry = self._record_audit(
+            ctx,
+            "welcome.post",
+            ok=True,
+            payload=data,
+            metadata={"channel_id": payload.channel_id},
+        )
+        return data, entry
+
+    # ------------------------------------------------------------------
+    # Guideline
+    # ------------------------------------------------------------------
+    def save_guideline(
+        self, ctx: RequestContext, payload: GuidelineTemplate
+    ) -> tuple[Dict[str, Any], AuditEntry]:
+        data = _dump_model(payload) or {}
+        with self._lock:
+            state = self._ensure_state(ctx.guild_id)
+            state.guideline = data
+        entry = self._record_audit(
+            ctx,
+            "guideline.save",
+            ok=True,
+            payload=data,
+        )
+        return data, entry
+
+    def test_guideline(
+        self, ctx: RequestContext, request: GuidelineTestRequest
+    ) -> tuple[Dict[str, Any], AuditEntry]:
+        with self._lock:
+            state = self._ensure_state(ctx.guild_id)
+            preview = state.guideline.copy() if state.guideline else {}
+        preview.update({
+            "target_user_id": request.target_user_id,
+            "dry_run": request.dry_run,
+        })
+        entry = self._record_audit(
+            ctx,
+            "guideline.test",
+            ok=True,
+            payload=preview,
+        )
+        return preview, entry
+
+    # ------------------------------------------------------------------
+    # Verify
+    # ------------------------------------------------------------------
+    def save_verify(
+        self, ctx: RequestContext, payload: VerifyConfig
+    ) -> tuple[Dict[str, Any], AuditEntry]:
+        data = _dump_model(payload) or {}
+        with self._lock:
+            state = self._ensure_state(ctx.guild_id)
+            state.verify = data
+        entry = self._record_audit(
+            ctx,
+            "verify.post",
+            ok=True,
+            payload=data,
+            metadata={"channel_id": payload.channel_id},
+        )
+        return data, entry
+
+    def remove_verify(self, ctx: RequestContext) -> AuditEntry:
+        with self._lock:
+            state = self._ensure_state(ctx.guild_id)
+            state.verify = None
+        return self._record_audit(ctx, "verify.remove", ok=True)
+
+    # ------------------------------------------------------------------
+    # Roles
+    # ------------------------------------------------------------------
+    def save_roles(
+        self, ctx: RequestContext, payload: RolesConfig
+    ) -> tuple[Dict[str, Any], AuditEntry]:
+        data = _dump_model(payload) or {}
+        with self._lock:
+            state = self._ensure_state(ctx.guild_id)
+            state.roles = data
+        entry = self._record_audit(
+            ctx,
+            "roles.post",
+            ok=True,
+            payload=data,
+            metadata={"channel_id": payload.channel_id},
+        )
+        return data, entry
+
+    def map_role_emoji(
+        self, ctx: RequestContext, payload: RoleEmojiMapRequest
+    ) -> tuple[Dict[str, str], AuditEntry]:
+        with self._lock:
+            state = self._ensure_state(ctx.guild_id)
+            if payload.emoji:
+                state.role_emoji_map[payload.role_id] = payload.emoji
+            else:
+                state.role_emoji_map.pop(payload.role_id, None)
+            mapping = dict(state.role_emoji_map)
+        entry = self._record_audit(
+            ctx,
+            "roles.mapEmoji",
+            ok=True,
+            payload={"role_id": payload.role_id, "emoji": payload.emoji},
+        )
+        return mapping, entry
+
+    def remove_role(
+        self, ctx: RequestContext, payload: RoleRemovalRequest
+    ) -> tuple[Optional[Dict[str, Any]], AuditEntry]:
+        with self._lock:
+            state = self._ensure_state(ctx.guild_id)
+            if payload.role_id is None:
+                state.roles = None
+                state.role_emoji_map.clear()
+            elif state.roles:
+                roles = [r for r in state.roles.get("roles", []) if r["role_id"] != payload.role_id]
+                state.roles["roles"] = roles
+            current = state.roles.copy() if state.roles else None
+        entry = self._record_audit(
+            ctx,
+            "roles.remove",
+            ok=True,
+            payload={"role_id": payload.role_id},
+        )
+        return current, entry
+
+    def preview_roles(
+        self, ctx: RequestContext, payload: RolesPreviewRequest
+    ) -> tuple[Dict[str, Any], AuditEntry]:
+        with self._lock:
+            state = self._ensure_state(ctx.guild_id)
+            preview = {
+                "style": state.roles.get("style") if state.roles else None,
+                "roles": state.roles.get("roles", []) if state.roles else [],
+                "emoji_map": dict(state.role_emoji_map),
+                "locale": payload.locale.value,
+            }
+        entry = self._record_audit(
+            ctx,
+            "roles.preview",
+            ok=True,
+            payload={"locale": payload.locale.value},
+        )
+        return preview, entry
+
+    # ------------------------------------------------------------------
+    # Introduce
+    # ------------------------------------------------------------------
+    def save_introduce(
+        self, ctx: RequestContext, payload: IntroduceConfig
+    ) -> tuple[Dict[str, Any], AuditEntry]:
+        data = _dump_model(payload) or {}
+        with self._lock:
+            state = self._ensure_state(ctx.guild_id)
+            state.introduce = data
+        entry = self._record_audit(
+            ctx,
+            "introduce.post",
+            ok=True,
+            payload=data,
+            metadata={"channel_id": payload.channel_id},
+        )
+        return data, entry
+
+    def save_introduce_schema(
+        self, ctx: RequestContext, payload: IntroduceSchema
+    ) -> tuple[Dict[str, Any], AuditEntry]:
+        data = _dump_model(payload) or {}
+        ids = [field["field_id"] for field in data.get("fields", [])]
+        if len(ids) != len(set(ids)):
+            raise ValueError("Duplicate field_id detected in introduce schema")
+        with self._lock:
+            state = self._ensure_state(ctx.guild_id)
+            state.introduce_schema = data
+        entry = self._record_audit(
+            ctx,
+            "introduce.schema.save",
+            ok=True,
+            payload=data,
+        )
+        return data, entry
+
+    # ------------------------------------------------------------------
+    # Scrims
+    # ------------------------------------------------------------------
+    def save_scrim_config(
+        self, ctx: RequestContext, payload: ScrimConfig
+    ) -> tuple[Dict[str, Any], AuditEntry]:
+        data = _dump_model(payload) or {}
+        with self._lock:
+            state = self._ensure_state(ctx.guild_id)
+            state.scrims = data
+        entry = self._record_audit(
+            ctx,
+            "scrims.config.save",
+            ok=True,
+            payload=data,
+        )
+        return data, entry
+
+    def run_scrim(
+        self, ctx: RequestContext, payload: ScrimRunRequest
+    ) -> tuple[Dict[str, Any], AuditEntry]:
+        with self._lock:
+            state = self._ensure_state(ctx.guild_id)
+            if not state.scrims:
+                raise ValueError("Scrim configuration is not set")
+            actions = []
+            for rule in state.scrims.get("rules", []):
+                actions.append(
+                    {
+                        "day": rule.get("day"),
+                        "notify_channel_id": rule.get("notify_channel_id"),
+                        "min_team_members": rule.get("min_team_members"),
+                        "status": "dry_run" if payload.dry_run else "scheduled",
+                    }
+                )
+        result = {"actions": actions, "dry_run": payload.dry_run}
+        entry = self._record_audit(
+            ctx,
+            "scrims.run",
+            ok=True,
+            payload=result,
+        )
+        return result, entry
+
+    # ------------------------------------------------------------------
+    # Settings
+    # ------------------------------------------------------------------
+    def save_settings(
+        self, ctx: RequestContext, payload: SettingsPayload
+    ) -> tuple[Dict[str, Any], AuditEntry]:
+        data = _dump_model(payload) or {}
+        with self._lock:
+            state = self._ensure_state(ctx.guild_id)
+            state.settings.update(data)
+        entry = self._record_audit(
+            ctx,
+            "settings.save",
+            ok=True,
+            payload=data,
+        )
+        return data, entry
+
+    # ------------------------------------------------------------------
+    # Audit search/export
+    # ------------------------------------------------------------------
+    def search_audit(
+        self, ctx: RequestContext, payload: AuditSearchRequest
+    ) -> tuple[List[Dict[str, Any]], AuditEntry]:
+        results: List[AuditEntry]
+        with self._lock:
+            results = [entry for entry in self._audit if entry.guild_id == ctx.guild_id]
+        filtered: List[AuditEntry] = []
+        for entry in results:
+            if payload.action and entry.action != payload.action:
+                continue
+            if payload.user_id and entry.actor_id != payload.user_id:
+                continue
+            if payload.channel_id and entry.metadata.get("channel_id") != payload.channel_id:
+                continue
+            if payload.since and entry.timestamp < payload.since:
+                continue
+            if payload.until and entry.timestamp > payload.until:
+                continue
+            filtered.append(entry)
+        # Latest entries first for the dashboard
+        filtered.sort(key=lambda e: e.timestamp, reverse=True)
+        limited = filtered[: payload.limit]
+        data = [entry.to_dict(include_payload=True) for entry in limited]
+        audit_entry = self._record_audit(
+            ctx,
+            "audit.search",
+            ok=True,
+            payload={"results": len(data)},
+        )
+        return data, audit_entry
+
+    def export_audit(
+        self, ctx: RequestContext, payload: AuditExportRequest
+    ) -> tuple[str, AuditEntry]:
+        results, _ = self.search_audit(ctx, payload)
+        text: str
+        if payload.format == AuditExportFormat.NDJSON:
+            lines = [json.dumps(row, ensure_ascii=False) for row in results]
+            text = "\n".join(lines)
+        else:
+            buffer = io.StringIO()
+            rows = []
+            fieldnames = set()
+            for row in results:
+                row_copy = dict(row)
+                payload_data = row_copy.pop("payload", None)
+                if payload_data is not None:
+                    row_copy["payload"] = json.dumps(payload_data, ensure_ascii=False)
+                rows.append(row_copy)
+                fieldnames.update(row_copy.keys())
+            writer = csv.DictWriter(buffer, fieldnames=sorted(fieldnames))
+            writer.writeheader()
+            for row in rows:
+                writer.writerow(row)
+            text = buffer.getvalue()
+        audit_entry = self._record_audit(
+            ctx,
+            "audit.export",
+            ok=True,
+            payload={"format": payload.format.value, "bytes": len(text.encode("utf-8"))},
+        )
+        return text, audit_entry
+
+    def log_failure(
+        self,
+        ctx: RequestContext,
+        action: str,
+        message: str,
+        *,
+        payload: Optional[Dict[str, Any]] = None,
+    ) -> AuditEntry:
+        """Utility for endpoints to record failed operations."""
+
+        return self._record_audit(
+            ctx,
+            action,
+            ok=False,
+            error=message,
+            payload=payload,
+        )
+
+
+# Shared singleton store used by the API
+STORE = Store()

--- a/tests/test_nyaimlab_api.py
+++ b/tests/test_nyaimlab_api.py
@@ -1,0 +1,97 @@
+"""Smoke tests covering the Nyaimlab management API endpoints."""
+
+from typing import Dict
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.nyaimlab import create_app
+
+
+@pytest.fixture(autouse=True)
+def _set_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("API_AUTH_TOKEN", "secret-token")
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = create_app()
+    return TestClient(app)
+
+
+@pytest.fixture
+def auth_headers() -> Dict[str, str]:
+    return {
+        "Authorization": "Bearer secret-token",
+        "x-client": "pytest",
+        "x-guild-id": "guild-123",
+        "x-user-id": "user-456",
+    }
+
+
+def test_welcome_configuration(client: TestClient, auth_headers: Dict[str, str]) -> None:
+    resp = client.post(
+        "/api/welcome.post",
+        json={"channel_id": "123"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert "audit_id" in body
+    assert body["data"]["config"]["channel_id"] == "123"
+
+
+def test_guideline_template_roundtrip(client: TestClient, auth_headers: Dict[str, str]) -> None:
+    save_resp = client.post(
+        "/api/guideline.save",
+        json={"content": "Welcome", "attachments": []},
+        headers=auth_headers,
+    )
+    assert save_resp.json()["ok"] is True
+
+    test_resp = client.post(
+        "/api/guideline.test",
+        json={},
+        headers=auth_headers,
+    )
+    body = test_resp.json()
+    assert body["ok"] is True
+    assert body["data"]["preview"]["content"] == "Welcome"
+
+
+def test_introduce_schema_duplicate_error(client: TestClient, auth_headers: Dict[str, str]) -> None:
+    resp = client.post(
+        "/api/introduce.schema.save",
+        json={
+            "fields": [
+                {"field_id": "name", "label": "Name"},
+                {"field_id": "name", "label": "Duplicate"},
+            ]
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 400
+    body = resp.json()
+    assert body["ok"] is False
+    assert "audit_id" in body
+    assert "Duplicate field_id" in body["error"]
+
+
+def test_state_snapshot_contains_saved_configuration(
+    client: TestClient, auth_headers: Dict[str, str]
+) -> None:
+    client.post(
+        "/api/welcome.post",
+        json={"channel_id": "999", "title_template": "Hello"},
+        headers=auth_headers,
+    )
+
+    snapshot = client.post("/api/state.snapshot", headers=auth_headers)
+    assert snapshot.status_code == 200
+    body = snapshot.json()
+    assert body["ok"] is True
+    state = body["data"]["state"]
+    assert state["welcome"]["channel_id"] == "999"
+    assert isinstance(state.get("audit_recent"), list)
+    assert state["audit_recent"]  # ensure at least one audit record is captured


### PR DESCRIPTION
## Summary
- reorganize the ESCL scrim collector into reusable session/collector components and clean scraper helpers
- extend the FastAPI store with snapshot support and richer schemas while adding a pytest configuration
- add a full GitHub Pages dashboard (docs/) covering welcome, guideline, verify, roles, introduce, scrims, audit and settings plus update README in Japanese
- resolve conflicts with the upstream management API merge, refresh the README with detailed Pages instructions and note the API test coverage

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cf1b5be39c832fae66a1527d6f9262